### PR TITLE
Fix issue with using UUID primary keys in complex return types

### DIFF
--- a/qrm/utill.go
+++ b/qrm/utill.go
@@ -170,7 +170,9 @@ func isSimpleModelType(objType reflect.Type) bool {
 	case reflect.Slice:
 		return objType.Elem().Kind() == reflect.Uint8 //[]byte
 	case reflect.Struct:
-		return objType == timeType || objType == uuidType // time.Time || uuid.UUID
+		return objType == timeType
+	case reflect.Array:
+		return objType == uuidType // uuid.UUID returns reflect.Array kind
 	}
 
 	return false


### PR DESCRIPTION
When using a UUID as a primary key with PostgreSQL the grouping was
defaulting to the row which caused incorrect results to be returned.