### PR TITLE
export OrderByClause type through alias

### DIFF
--- a/mysql/delete_statement.go
+++ b/mysql/delete_statement.go
@@ -7,7 +7,7 @@ type DeleteStatement interface {
 	Statement
 
 	WHERE(expression BoolExpression) DeleteStatement
-	ORDER_BY(orderByClauses ...jet.OrderByClause) DeleteStatement
+	ORDER_BY(orderByClauses ...OrderByClause) DeleteStatement
 	LIMIT(limit int64) DeleteStatement
 }
 
@@ -38,7 +38,7 @@ func (d *deleteStatementImpl) WHERE(expression BoolExpression) DeleteStatement {
 	return d
 }
 
-func (d *deleteStatementImpl) ORDER_BY(orderByClauses ...jet.OrderByClause) DeleteStatement {
+func (d *deleteStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) DeleteStatement {
 	d.OrderBy.List = orderByClauses
 	return d
 }

--- a/mysql/select_statement.go
+++ b/mysql/select_statement.go
@@ -46,7 +46,7 @@ type SelectStatement interface {
 	GROUP_BY(groupByClauses ...jet.GroupByClause) SelectStatement
 	HAVING(boolExpression BoolExpression) SelectStatement
 	WINDOW(name string) windowExpand
-	ORDER_BY(orderByClauses ...jet.OrderByClause) SelectStatement
+	ORDER_BY(orderByClauses ...OrderByClause) SelectStatement
 	LIMIT(limit int64) SelectStatement
 	OFFSET(offset int64) SelectStatement
 	FOR(lock RowLock) SelectStatement
@@ -128,7 +128,7 @@ func (s *selectStatementImpl) WINDOW(name string) windowExpand {
 	return windowExpand{selectStatement: s}
 }
 
-func (s *selectStatementImpl) ORDER_BY(orderByClauses ...jet.OrderByClause) SelectStatement {
+func (s *selectStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) SelectStatement {
 	s.OrderBy.List = orderByClauses
 	return s
 }

--- a/mysql/set_statement.go
+++ b/mysql/set_statement.go
@@ -17,7 +17,7 @@ func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatem
 type setStatement interface {
 	setOperators
 
-	ORDER_BY(orderByClauses ...jet.OrderByClause) setStatement
+	ORDER_BY(orderByClauses ...OrderByClause) setStatement
 
 	LIMIT(limit int64) setStatement
 	OFFSET(offset int64) setStatement
@@ -70,7 +70,7 @@ func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStat
 	return newSetStatement
 }
 
-func (s *setStatementImpl) ORDER_BY(orderByClauses ...jet.OrderByClause) setStatement {
+func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) setStatement {
 	s.setOperator.OrderBy.List = orderByClauses
 	return s
 }

--- a/mysql/types.go
+++ b/mysql/types.go
@@ -17,5 +17,8 @@ type ColumnAssigment = jet.ColumnAssigment
 // PrintableStatement is a statement which sql query can be logged
 type PrintableStatement = jet.PrintableStatement
 
+// OrderByClause is the combination of an expression and the wanted ordering to use as input for ORDER BY.
+type OrderByClause = jet.OrderByClause
+
 // SetLogger sets automatic statement logging
 var SetLogger = jet.SetLoggerFunc

--- a/postgres/select_statement.go
+++ b/postgres/select_statement.go
@@ -49,7 +49,7 @@ type SelectStatement interface {
 	GROUP_BY(groupByClauses ...jet.GroupByClause) SelectStatement
 	HAVING(boolExpression BoolExpression) SelectStatement
 	WINDOW(name string) windowExpand
-	ORDER_BY(orderByClauses ...jet.OrderByClause) SelectStatement
+	ORDER_BY(orderByClauses ...OrderByClause) SelectStatement
 	LIMIT(limit int64) SelectStatement
 	OFFSET(offset int64) SelectStatement
 	FOR(lock RowLock) SelectStatement
@@ -131,7 +131,7 @@ func (s *selectStatementImpl) WINDOW(name string) windowExpand {
 	return windowExpand{selectStatement: s}
 }
 
-func (s *selectStatementImpl) ORDER_BY(orderByClauses ...jet.OrderByClause) SelectStatement {
+func (s *selectStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) SelectStatement {
 	s.OrderBy.List = orderByClauses
 	return s
 }

--- a/postgres/set_statement.go
+++ b/postgres/set_statement.go
@@ -41,7 +41,7 @@ func EXCEPT_ALL(lhs, rhs jet.SerializerStatement) setStatement {
 type setStatement interface {
 	setOperators
 
-	ORDER_BY(orderByClauses ...jet.OrderByClause) setStatement
+	ORDER_BY(orderByClauses ...OrderByClause) setStatement
 
 	LIMIT(limit int64) setStatement
 	OFFSET(offset int64) setStatement
@@ -114,7 +114,7 @@ func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStat
 	return newSetStatement
 }
 
-func (s *setStatementImpl) ORDER_BY(orderByClauses ...jet.OrderByClause) setStatement {
+func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) setStatement {
 	s.setOperator.OrderBy.List = orderByClauses
 	return s
 }

--- a/postgres/types.go
+++ b/postgres/types.go
@@ -17,5 +17,8 @@ type ColumnAssigment = jet.ColumnAssigment
 // PrintableStatement is a statement which sql query can be logged
 type PrintableStatement = jet.PrintableStatement
 
+// OrderByClause is the combination of an expression and the wanted ordering to use as input for ORDER BY.
+type OrderByClause = jet.OrderByClause
+
 // SetLogger sets automatic statement logging
 var SetLogger = jet.SetLoggerFunc


### PR DESCRIPTION
enables e.g. creating a collection of clauses beforehand and dynamically adding to it.
this resolves #48.