### PR TITLE
Add support for custom functions.

### DIFF
--- a/internal/jet/func_expression.go
+++ b/internal/jet/func_expression.go
@@ -801,3 +801,8 @@ func newTimestampzFunc(name string, expressions ...Expression) *timestampzFunc {
 
 	return timestampzFunc
 }
+
+// Func can be used to call an custom or as of yet unsupported function in the database.
+func Func(name string, expressions ...Expression) Expression {
+	return newFunc(name, expressions, nil)
+}

--- a/internal/jet/func_expression_test.go
+++ b/internal/jet/func_expression_test.go
@@ -176,3 +176,7 @@ func TestTO_ASCII(t *testing.T) {
 	assertClauseSerialize(t, TO_ASCII(String("Karel")), `TO_ASCII($1)`, "Karel")
 	assertClauseSerialize(t, TO_ASCII(String("Karel")), `TO_ASCII($1)`, "Karel")
 }
+
+func TestFunc(t *testing.T) {
+	assertClauseSerialize(t, Func("FOO", String("test"), NULL, MAX(Int(1))), "FOO($1, NULL, MAX($2))", "test", int64(1))
+}

--- a/mysql/expressions.go
+++ b/mysql/expressions.go
@@ -74,5 +74,8 @@ var TimestampExp = jet.TimestampExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// Func can be used to call an custom or as of yet unsupported function in the database.
+var Func = jet.Func
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -85,5 +85,8 @@ var TimestampzExp = jet.TimestampzExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// Func can be used to call an custom or as of yet unsupported function in the database.
+var Func = jet.Func
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue


### PR DESCRIPTION
This allows expressions like jet.Func("FOO", String("test")) to be
emitted as FOO($1).