### PR TITLE
Expose the WRAP expression

### DIFF
--- a/mysql/expressions.go
+++ b/mysql/expressions.go
@@ -74,5 +74,8 @@ var TimestampExp = jet.TimestampExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// WRAP wraps list of expressions with brackets '(' and ')'
+var WRAP = jet.WRAP
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -85,5 +85,8 @@ var TimestampzExp = jet.TimestampzExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// WRAP wraps list of expressions with brackets '(' and ')'
+var WRAP = jet.WRAP
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue


### PR DESCRIPTION
Potential fix for https://github.com/go-jet/jet/issues/66
This allows the following queries to be performed:
```golang
SELECT(FieldMetric.AllColumns).
	FROM(FieldMetric).
	WHERE(
		StringExp(WRAP(FieldMetric.ClientID, FieldMetric.ServerID, FieldMetric.FieldID)).IN(
			WRAP(String("0176ef3a-b3b3-5a02-ebf4-656af08d6746"),
				String("0176ef3a-b3f5-7e63-7995-f4cd0a2f63c5"),
				String("0176ef3a-b7ae-ba5a-2a98-bbd3007e66a7"))),
	)
```

Not sure if we should do a "columns" expression instead @go-jet?