### PR TITLE
Add RawP expression

### DIFF
--- a/internal/jet/literal_expression_test.go
+++ b/internal/jet/literal_expression_test.go
@@ -1,6 +1,7 @@
 package jet
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -11,6 +12,18 @@ func TestRawExpression(t *testing.T) {
 	var timeT = time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 
 	assertClauseSerialize(t, DateT(timeT), "$1", timeT)
+}
+
+func TestRawParameterizedExpresion(t *testing.T) {
+	var expressions []Expression
+	for i:=1; i <= 10; i++ {
+		expressions = append(expressions, String(fmt.Sprintf("test%d",i)))
+	}
+	assertClauseSerialize(t, RawP("my_function($1,$2)", String("test1"), String("test2")), "my_function($1,$2)", "test1", "test2")
+	assertClauseSerialize(t, RawP("$1", String("test1")), "$1", "test1")
+	assertClauseSerialize(t, RawP("my_function($10)", expressions...), "my_function($1)", "test10")
+	assertClauseSerializeErr(t, RawP("my_function($)"), "jet: raw expression cannot contain $")
+	assertClauseSerializeErr(t, RawP("my_function($1,$2)", String("test")), "jet: index of $ was not found in list of parameters")
 }
 
 func TestTimeLiteral(t *testing.T) {

--- a/mysql/expressions.go
+++ b/mysql/expressions.go
@@ -74,5 +74,9 @@ var TimestampExp = jet.TimestampExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// Raw can be used for any unsupported functions, operators or expressions that require parameters.
+// For example: RawP("my_function($1)", String("my_parameter"))
+var RawP = jet.RawP
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -85,5 +85,9 @@ var TimestampzExp = jet.TimestampzExp
 // For example: Raw("current_database()")
 var Raw = jet.Raw
 
+// Raw can be used for any unsupported functions, operators or expressions that require parameters.
+// For example: RawP("my_function($1)", String("my_parameter"))
+var RawP = jet.RawP
+
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue


### PR DESCRIPTION
Fixes https://github.com/go-jet/jet/issues/65
It takes a similar approach as `fmt.Sprintf`, let me know if you like it.

The only thing is that you can't set parents when using parameters, any idea on how to fix that?
Maybe we could add a `Parent` helper that adds the parents to a given expression.