### PR TITLE
Connection via DSN

### DIFF
--- a/generator/mysql/mysql_generator.go
+++ b/generator/mysql/mysql_generator.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/generator/template"
@@ -43,6 +44,14 @@ func Generate(destDir string, dbConn DBConnection, generatorTemplate ...template
 // GenerateDSN opens connection via DSN string and does everything what Generate does.
 func GenerateDSN(dsn, destDir string, templates ...template.Template) (err error) {
 	defer utils.ErrorCatch(&err)
+
+	// Special case for go mysql driver. It does not understand schema,
+	// so we need to trim it before passing to generator
+	// https://github.com/go-sql-driver/mysql#dsn-data-source-name
+	idx := strings.Index(dsn, "://")
+	if idx != -1 {
+		dsn = dsn[idx+len("://"):]
+	}
 
 	cfg, err := mysqldr.ParseDSN(dsn)
 	throw.OnError(err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/go-cmp v0.5.0 //tests
 	github.com/google/uuid v1.1.1
+	github.com/jackc/pgconn v1.8.1
 	github.com/jackc/pgx/v4 v4.11.0 //tests
 	github.com/lib/pq v1.7.0
 	github.com/pkg/profile v1.5.0 //tests

--- a/go.sum
+++ b/go.sum
@@ -42,7 +42,6 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -457,7 +456,6 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tests/init/init.go
+++ b/tests/init/init.go
@@ -4,16 +4,17 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/go-jet/jet/v2/generator/mysql"
 	"github.com/go-jet/jet/v2/generator/postgres"
 	"github.com/go-jet/jet/v2/internal/utils/throw"
 	"github.com/go-jet/jet/v2/tests/dbconfig"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 var testSuite string


### PR DESCRIPTION
Allow to connect via DSN https://github.com/go-jet/jet/issues/88. For postgresql and mysql generators.

Added not required parameter `-dsn`. When this new flag is provided, all other connection flags is ignored. It tries to detect source by connection string, specially by `scheme` prefix. 
If string provided without `scheme` (e.g. `postgresql://`, `mysql://`, etc.), `-source` flag is required.
```sh
$ jet -source=PostgreSQL -host=localhost -port=5432 -user=postgres -password="" -dbname=service # old-way

$ jet -dsn=postgresql://postgres@localhost:5432/service # postgres
$ jet -source=MySQL -dsn=root@tcp(localhost:3306)/service # mysql
$ jet -dsn=mysql://root@tcp(localhost:3306)/service # mysql 2
```

Docs for DSN: [PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) [MySQL](https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html)
Examples: 
```
postgresql://user:pass@localhost/otherdb?connect_timeout=10&application_name=myapp
postgresql://host:123/somedb?target_session_attrs=any&application_name=myapp

mysql://user@localhost:3306
mysql://username:password@protocol(address)/dbname?param=value
```