### PR TITLE
Add postgres json literal

### DIFF
--- a/postgres/literal.go
+++ b/postgres/literal.go
@@ -65,6 +65,11 @@ func String(value string) StringExpression {
 	return CAST(jet.String(value)).AS_TEXT()
 }
 
+// Json creates new json literal expression
+func Json(value string) StringExpression {
+	return StringExp(CAST(jet.String(value)).AS("json"))
+}
+
 // UUID is a helper function to create string literal expression from uuid object
 // value can be any uuid type with a String method
 var UUID = jet.UUID

--- a/postgres/literal.go
+++ b/postgres/literal.go
@@ -66,8 +66,13 @@ func String(value string) StringExpression {
 }
 
 // Json creates new json literal expression
-func Json(value string) StringExpression {
-	return StringExp(CAST(jet.String(value)).AS("json"))
+func Json(value interface{}) StringExpression {
+	switch value.(type) {
+	case string, []byte:
+	default:
+		panic("Bytea parameter value has to be of the type string or []byte")
+	}
+	return StringExp(CAST(jet.Literal(value)).AS("json"))
 }
 
 // UUID is a helper function to create string literal expression from uuid object

--- a/postgres/literal_test.go
+++ b/postgres/literal_test.go
@@ -67,6 +67,11 @@ func TestBytea(t *testing.T) {
 	assertSerialize(t, Bytea([]byte("Some byte array")), `$1::bytea`, []byte("Some byte array"))
 }
 
+func TestJson(t *testing.T) {
+	assertSerialize(t, Json("{\"key\": \"value\"}"), `$1::json`, "{\"key\": \"value\"}")
+	assertSerialize(t, Json([]byte("{\"key\": \"value\"}")), `$1::json`, []byte("{\"key\": \"value\"}"))
+}
+
 func TestDate(t *testing.T) {
 	assertSerialize(t, Date(2014, time.January, 2), `$1::date`, "2014-01-02")
 	assertSerialize(t, DateT(time.Now()), `$1::date`)


### PR DESCRIPTION
Json types are crucial for postgres. This PR add support to easily cast golang string as postgres json type.

Solves https://github.com/go-jet/jet/issues/160.