### PR TITLE
fix: Add omitted reserved word 'RIGHT' on postgresql

### DIFF
--- a/postgres/dialect.go
+++ b/postgres/dialect.go
@@ -167,6 +167,7 @@ var reservedWords = []string{
 	"PRIMARY",
 	"REFERENCES",
 	"RETURNING",
+	"RIGHT",
 	"SELECT",
 	"SESSION_USER",
 	"SOME",


### PR DESCRIPTION
https://www.postgresql.org/docs/current/sql-keywords-appendix.html

Seems like reserved word "RIGHT" omitted in the `reservedWords` in the postgresql dialect
