### PR TITLE
SQLite: allow generate from schema file

### DIFF
--- a/generator/sqlite/sqlite_generator.go
+++ b/generator/sqlite/sqlite_generator.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+	"os"
+
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/generator/template"
 	"github.com/go-jet/jet/v2/internal/utils"
@@ -11,12 +13,31 @@ import (
 )
 
 // GenerateDSN generates jet files using dsn connection string
-func GenerateDSN(dsn, destDir string, templates ...template.Template) (err error) {
+func GenerateDSN(dsn, destDir string, templates ...template.Template) error {
+	return generate(dsn, "", destDir, templates...)
+}
+
+func GenerateFromSchema(dsn, fromSchemaFile, destDir string, templates ...template.Template) error {
+	if dsn == "" {
+		dsn = ":memory:"
+	}
+	return generate(dsn, fromSchemaFile, destDir, templates...)
+}
+
+func generate(dsn, fromSchemaFile, destDir string, templates ...template.Template) (err error) {
 	defer utils.ErrorCatch(&err)
 
 	db, err := sql.Open("sqlite3", dsn)
 	throw.OnError(err)
 	defer utils.DBClose(db)
+
+	if fromSchemaFile != "" {
+		fmt.Println("Writing schema information...")
+		schema, err := os.ReadFile(fromSchemaFile)
+		throw.OnError(err)
+		_, err = db.Exec(string(schema))
+		throw.OnError(err)
+	}
 
 	fmt.Println("Retrieving schema information...")
 


### PR DESCRIPTION
Sometimes is handy to generate files from schema files (see for example https://github.com/go-jet/jet/issues/136).

In general this is hard to do. In SQLite it is so easy to create an in-memory throw-away database that this can be easily accomplished.

This PR propose to add a flag to specify a schema file that will be used to generate files. If no DSN is specified, an temporary in-memory database will be used, otherwise the schema file will be executed in the specified database.

In order for this to work, a change to the test data is needed: https://github.com/go-jet/jet-test-data/pull/2

The README/Wiki should also be updated with this new flag.

What do you think?
