### PR TITLE
Add DefaultAlias option to TableSQLBuilder

### DIFF
--- a/generator/template/file_templates.go
+++ b/generator/template/file_templates.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-jet/jet/v2/{{dialect.PackageName}}"
 )
 
-var {{tableTemplate.InstanceName}} = new{{tableTemplate.TypeName}}("{{schemaName}}", "{{.Name}}", "")
+var {{tableTemplate.InstanceName}} = new{{tableTemplate.TypeName}}("{{schemaName}}", "{{.Name}}", "{{tableTemplate.DefaultAlias}}")
 
 type {{structImplName}} struct {
 	{{dialect.PackageName}}.Table

--- a/generator/template/sql_builder_template.go
+++ b/generator/template/sql_builder_template.go
@@ -59,6 +59,7 @@ type TableSQLBuilder struct {
 	FileName     string
 	InstanceName string
 	TypeName     string
+	DefaultAlias string
 	Column       func(columnMetaData metadata.Column) TableSQLBuilderColumn
 }
 
@@ -72,6 +73,7 @@ func DefaultTableSQLBuilder(tableMetaData metadata.Table) TableSQLBuilder {
 		FileName:     dbidentifier.ToGoFileName(tableMetaData.Name),
 		InstanceName: dbidentifier.ToGoIdentifier(tableMetaData.Name),
 		TypeName:     dbidentifier.ToGoIdentifier(tableMetaData.Name) + "Table",
+		DefaultAlias: "",
 		Column:       DefaultTableSQLBuilderColumn,
 	}
 }
@@ -109,6 +111,12 @@ func (tb TableSQLBuilder) UseInstanceName(name string) TableSQLBuilder {
 // UseTypeName returns new TableSQLBuilder with new type name set
 func (tb TableSQLBuilder) UseTypeName(name string) TableSQLBuilder {
 	tb.TypeName = name
+	return tb
+}
+
+// UseDefaultAlias returns new TableSQLBuilder with new default alias set
+func (tb TableSQLBuilder) UseDefaultAlias(defaultAlias string) TableSQLBuilder {
+	tb.DefaultAlias = defaultAlias
 	return tb
 }
 

--- a/tests/mysql/generator_template_test.go
+++ b/tests/mysql/generator_template_test.go
@@ -285,6 +285,29 @@ func TestGeneratorTemplate_SQLBuilder_ChangeTypeAndFileName(t *testing.T) {
 	require.Contains(t, mpaaRating, "var FilmRatingEnumSQLBuilder = &struct {")
 }
 
+func TestGeneratorTemplate_SQLBuilder_DefaultAlias(t *testing.T) {
+	err := mysql2.Generate(
+		tempTestDir,
+		dbConnection("dvds"),
+		template.Default(postgres2.Dialect).
+			UseSchema(func(schemaMetaData metadata.Schema) template.Schema {
+				return template.DefaultSchema(schemaMetaData).
+					UseSQLBuilder(template.DefaultSQLBuilder().
+						UseTable(func(table metadata.Table) template.TableSQLBuilder {
+							if table.Name == "actor" {
+								return template.DefaultTableSQLBuilder(table).UseDefaultAlias("actors")
+							}
+							return template.DefaultTableSQLBuilder(table)
+						}),
+					)
+			}),
+	)
+	require.Nil(t, err)
+
+	actor := file2.Exists(t, defaultTableSQLBuilderFilePath, "actor.go")
+	require.Contains(t, actor, "var Actor = newActorTable(\"dvds\", \"actor\", \"actors\")")
+}
+
 func TestGeneratorTemplate_Model_AddTags(t *testing.T) {
 
 	err := mysql2.Generate(


### PR DESCRIPTION
The following code
```
func generateJetTypes(connectionString string) error {
	return jet.GenerateDSN(connectionString, "public", "gen", template.Default(postgres.Dialect).
		UseSchema(func(schemaMetaData metadata.Schema) template.Schema {
			return template.DefaultSchema(schemaMetaData)
			.UseSQLBuilder(template.DefaultSQLBuilder().
				UseTable(func(table metadata.Table) template.TableSQLBuilder {
					return template.DefaultTableSQLBuilder(table).UseDefaultAlias(strings.Trim(table.Name, "s"))
				}))
		}))
}
```
generates the following output 
```
(...)
var Users = newUsersTable("public", "users", "user")

type usersTable struct {
(...)
```
for the following table 
```
CREATE TABLE users (
    id UUID PRIMARY KEY,
    name character varying(45) NOT NULL,
    surname character varying(45) NOT NULL,
    updated_at timestamp without time zone NOT NULL,
    created_at timestamp without time zone NOT NULL
);
```
