### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,23 +105,23 @@ Done
 ```
 Procedure is similar for MySQL, CockroachDB, MariaDB and SQLite. For example:
 ```sh
-jet -source=mysql -dsn="user:pass@tcp(localhost:3306)/dbname" -path=./gen
+jet -source=mysql -dsn="user:pass@tcp(localhost:3306)/dbname" -path=./.gen
 jet -dsn=postgres://user:pass@localhost:26257/jetdb?sslmode=disable -schema=dvds -path=./.gen  #cockroachdb
-jet -dsn="mariadb://user:pass@tcp(localhost:3306)/dvds" -path=./gen              # source flag can be omitted if data source appears in dsn
-jet -source=sqlite -dsn="/path/to/sqlite/database/file" -schema=dvds -path=./gen
-jet -dsn="file:///path/to/sqlite/database/file" -schema=dvds -path=./gen         # sqlite database assumed for 'file' data sources
+jet -dsn="mariadb://user:pass@tcp(localhost:3306)/dvds" -path=./.gen              # source flag can be omitted if data source appears in dsn
+jet -source=sqlite -dsn="/path/to/sqlite/database/file" -schema=dvds -path=./.gen
+jet -dsn="file:///path/to/sqlite/database/file" -schema=dvds -path=./.gen         # sqlite database assumed for 'file' data sources
 ```
 _*User has to have a permission to read information schema tables._
 
 As command output suggest, Jet will:
 - connect to postgres database and retrieve information about the _tables_, _views_ and _enums_ of `dvds` schema
-- delete everything in schema destination folder -  `./gen/jetdb/dvds`,   
+- delete everything in schema destination folder -  `./.gen/jetdb/dvds`,   
 - and finally generate SQL Builder and Model types for each schema table, view and enum.  
 
 
 Generated files folder structure will look like this:
 ```sh 
-|-- gen                               # -path
+|-- .gen                              # -path
 |   `-- jetdb                         # database name
 |       `-- dvds                      # schema name
 |           |-- enum                  # sql builder package for enums
@@ -156,7 +156,7 @@ import (
 	. "github.com/go-jet/jet/v2/examples/quick-start/.gen/jetdb/dvds/table"
 	. "github.com/go-jet/jet/v2/postgres"
 
-	"github.com/go-jet/jet/v2/examples/quick-start/gen/jetdb/dvds/model"
+	"github.com/go-jet/jet/v2/examples/quick-start/.gen/jetdb/dvds/model"
 )
 ```
 Let's say we want to retrieve the list of all _actors_ that acted in _films_ longer than 180 minutes, _film language_ is 'English' 


### PR DESCRIPTION
An example in README uses two destination paths: `gen/` and `.gen/` . This is confusing and the latter seems correct according to the actual code, so I fixed it.

https://github.com/go-jet/jet/blob/33333585e9571ee4375c1a6ee99acff129c801ba/examples/quick-start/quick-start.go#L16