### PR TITLE
10x mysql db info querying speedup

### DIFF
--- a/generator/mysql/mysql_generator.go
+++ b/generator/mysql/mysql_generator.go
@@ -12,6 +12,8 @@ import (
 	mysqldr "github.com/go-sql-driver/mysql"
 )
 
+const mysqlMaxConns = 10
+
 // DBConnection contains MySQL connection details
 type DBConnection struct {
 	Host     string
@@ -82,6 +84,9 @@ func openConnection(connectionString string) (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open mysql connection: %w", err)
 	}
+
+	db.SetMaxOpenConns(mysqlMaxConns)
+	db.SetMaxIdleConns(mysqlMaxConns)
 
 	err = db.Ping()
 	if err != nil {

--- a/generator/mysql/query_set.go
+++ b/generator/mysql/query_set.go
@@ -39,27 +39,36 @@ ORDER BY table_name;
 
 func (m mySqlQuerySet) GetTableColumnsMetaData(db *sql.DB, schemaName string, tableName string) ([]metadata.Column, error) {
 	query := `
-SELECT COLUMN_NAME AS "column.Name", 
-	IS_NULLABLE = "YES" AS "column.IsNullable",
-	columns.COLUMN_COMMENT as "column.Comment",
-	(EXISTS(
-		SELECT 1
+SELECT
+		col.COLUMN_NAME AS "column.Name",
+		col.IS_NULLABLE = "YES" AS "column.IsNullable",
+		col.COLUMN_COMMENT AS "column.Comment",
+		pk.IsPrimaryKey AS "column.IsPrimaryKey",
+		IF (col.COLUMN_TYPE = 'tinyint(1)',
+				'boolean',
+				IF (col.DATA_TYPE = 'enum',
+						CONCAT(col.TABLE_NAME, '_', col.COLUMN_NAME),
+						col.DATA_TYPE)
+		) AS "dataType.Name",
+		IF (col.DATA_TYPE = 'enum', 'enum', 'base') AS "dataType.Kind",
+		col.COLUMN_TYPE LIKE '%unsigned%' AS "dataType.IsUnsigned"
+FROM
+		information_schema.columns AS col
+LEFT JOIN (
+		SELECT k.column_name, 1 AS IsPrimaryKey
 		FROM information_schema.table_constraints t
-			JOIN information_schema.key_column_usage k USING(constraint_name,table_schema,table_name)
-		WHERE table_schema = ? AND table_name = ? AND t.constraint_type='PRIMARY KEY' AND k.column_name = columns.column_name
-	)) AS "column.IsPrimaryKey",
-	IF (COLUMN_TYPE = 'tinyint(1)', 
-			'boolean', 
-			IF (DATA_TYPE='enum', 
-					CONCAT(TABLE_NAME, '_', COLUMN_NAME), 
-					DATA_TYPE)
-	) AS "dataType.Name", 
-	IF (DATA_TYPE = 'enum', 'enum', 'base') AS "dataType.Kind", 
-	COLUMN_TYPE LIKE '%unsigned%' AS "dataType.IsUnsigned"
-FROM information_schema.columns
-WHERE table_schema = ? AND table_name = ?
-ORDER BY ordinal_position;
-`
+		JOIN information_schema.key_column_usage k USING(constraint_name, table_schema, table_name)
+		WHERE t.table_schema =  ?
+			AND t.table_name = ?
+			AND t.constraint_type = 'PRIMARY KEY'
+) AS pk ON col.COLUMN_NAME = pk.column_name
+WHERE
+		col.table_schema = ?
+		AND col.table_name = ?
+ORDER BY
+		col.ordinal_position;
+	`
+
 	var columns []metadata.Column
 	_, err := qrm.Query(context.Background(), db, query, []interface{}{schemaName, tableName, schemaName, tableName}, &columns)
 	if err != nil {

--- a/generator/mysql/query_set.go
+++ b/generator/mysql/query_set.go
@@ -28,10 +28,6 @@ ORDER BY table_name;
 		return nil, fmt.Errorf("failed to query %s metadata result: %w", tableType, err)
 	}
 
-	const maxConns = 32
-	db.SetMaxOpenConns(maxConns)
-	db.SetMaxIdleConns(maxConns)
-
 	wg := errgroup.Group{}
 	for i := 0; i < len(tables); i++ {
 		i := i

--- a/generator/mysql/query_set.go
+++ b/generator/mysql/query_set.go
@@ -74,7 +74,7 @@ SELECT
 		col.COLUMN_NAME AS "column.Name",
 		col.IS_NULLABLE = "YES" AS "column.IsNullable",
 		col.COLUMN_COMMENT AS "column.Comment",
-		pk.IsPrimaryKey AS "column.IsPrimaryKey",
+		COALESCE(pk.IsPrimaryKey, 0) AS "column.IsPrimaryKey",
 		IF (col.COLUMN_TYPE = 'tinyint(1)',
 				'boolean',
 				IF (col.DATA_TYPE = 'enum',

--- a/generator/mysql/query_set.go
+++ b/generator/mysql/query_set.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/qrm"
+	"golang.org/x/sync/errgroup"
 )
 
 // mySqlQuerySet is dialect query set for MySQL
@@ -29,43 +28,21 @@ ORDER BY table_name;
 		return nil, fmt.Errorf("failed to query %s metadata result: %w", tableType, err)
 	}
 
-	tblChan := make(chan int, len(tables))
-	errChan := make(chan error, 1)
+	const maxConns = 32
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
 
-	wg := sync.WaitGroup{}
-	for i := 0; i < runtime.NumCPU(); i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			var err1 error
-			for tblIdx := range tblChan {
-				tables[tblIdx].Columns, err1 = m.GetTableColumnsMetaData(db, schemaName, tables[tblIdx].Name)
-				if err1 != nil {
-					select {
-					case errChan <- fmt.Errorf("failed to get '%s' table columns metadata: %w", tables[tblIdx].Name, err1):
-						return
-					default:
-					}
-					return
-				}
-			}
-		}()
+	wg := errgroup.Group{}
+	for i := 0; i < len(tables); i++ {
+		i := i
+		wg.Go(func() (err1 error) {
+			tables[i].Columns, err1 = m.GetTableColumnsMetaData(db, schemaName, tables[i].Name)
+			return err1
+		})
 	}
 
-	for i := range tables {
-		tblChan <- i
-	}
-
-	close(tblChan)
-	wg.Wait()
-
-	select {
-	case err = <-errChan:
-		return nil, err
-	default:
-	}
-
-	return tables, nil
+	err = wg.Wait()
+	return tables, err
 }
 
 func (m mySqlQuerySet) GetTableColumnsMetaData(db *sql.DB, schemaName string, tableName string) ([]metadata.Column, error) {

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,6 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.2
 	github.com/volatiletech/null/v8 v8.1.2
+	golang.org/x/sync v0.3.0
 	gopkg.in/guregu/null.v4 v4.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Optimisation consists of two parts:
- faster SQL query
- leverage concurrency

Sample run:
```sh
$ jet -source=mysql -dsn="$MYSQL_USER:$MYSQL_PASS@tcp(localhost:$MYSQL_PORT)/facility" -path=./gen
Connecting to MySQL database...
Retrieving database information...
        FOUND 148 table(s), 162 view(s), 13 enum(s)
Destination directory: gen/facility
Cleaning up destination directory...
Generating table model files...
Generating view model files...
Generating enum model files...
Generating table sql builder files
Generating view sql builder files
Generating enum sql builder files
```

Results:
- master: 4m9s
- with improved SQL:  42s
- with improved SQL + concurrency: 21s

Tested with MySQL 5.7 running locally in Docker.