### PR TITLE
Add support for OF in row lock clauses

### DIFF
--- a/mysql/select_statement_test.go
+++ b/mysql/select_statement_test.go
@@ -123,6 +123,11 @@ SELECT table1.col_bool AS "table1.col_bool"
 FROM db.table1
 FOR SHARE NOWAIT;
 `)
+	testutils.AssertStatementSql(t, SELECT(table1ColBool).FROM(table1).FOR(UPDATE().OF(table1).NOWAIT()), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+FOR UPDATE OF table1 NOWAIT;
+`)
 }
 
 func TestSelect_LOCK_IN_SHARE_MODE(t *testing.T) {

--- a/postgres/select_statement_test.go
+++ b/postgres/select_statement_test.go
@@ -133,4 +133,10 @@ SELECT table1.col_bool AS "table1.col_bool"
 FROM db.table1
 FOR NO KEY UPDATE SKIP LOCKED;
 `)
+
+	assertStatementSql(t, SELECT(table1ColBool).FROM(table1).FOR(UPDATE().OF(table1, table2).NOWAIT()), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+FOR UPDATE OF table1, table2 NOWAIT;
+`)
 }

--- a/tests/postgres/select_test.go
+++ b/tests/postgres/select_test.go
@@ -2251,6 +2251,18 @@ FOR`
 	}
 }
 
+func TestRowLockWithJoins(t *testing.T) {
+	query := SELECT(STAR).
+		FROM(
+			Film.
+				INNER_JOIN(FilmCategory, FilmCategory.FilmID.EQ(Film.FilmID)).
+				LEFT_JOIN(FilmActor, FilmActor.FilmID.EQ(Film.FilmID))).
+		LIMIT(1).
+		FOR(UPDATE().OF(Film, FilmCategory).NOWAIT())
+
+	testutils.AssertExecAndRollback(t, query, db, 1)
+}
+
 func TestQuickStart(t *testing.T) {
 
 	var expectedSQL = `


### PR DESCRIPTION
This adds support for statements such as `SELECT ... FOR UPDATE OF table NOWAIT` where `OF table` could not be specified previously. Fixes #285.