### PR TITLE
Handle plus and minus identifiers better

### DIFF
--- a/internal/utils/dbidentifier/dbidentifier.go
+++ b/internal/utils/dbidentifier/dbidentifier.go
@@ -1,24 +1,39 @@
 package dbidentifier
 
 import (
-	"github.com/go-jet/jet/v2/internal/3rdparty/snaker"
 	"strings"
+
+	"github.com/go-jet/jet/v2/internal/3rdparty/snaker"
 )
 
 // ToGoIdentifier converts database identifier to Go identifier.
 func ToGoIdentifier(databaseIdentifier string) string {
-	return snaker.SnakeToCamel(replaceInvalidChars(databaseIdentifier))
+	return snaker.SnakeToCamel(replaceInvalidChars(replaceSuffixes(databaseIdentifier)))
 }
 
 // ToGoFileName converts database identifier to Go file name.
 func ToGoFileName(databaseIdentifier string) string {
-	return strings.ToLower(replaceInvalidChars(databaseIdentifier))
+	return strings.ToLower(replaceInvalidChars(replaceSuffixes(databaseIdentifier)))
 }
 
 func replaceInvalidChars(str string) string {
 	str = strings.Replace(str, " ", "_", -1)
-	str = strings.Replace(str, "-", "_", -1)
 	str = strings.Replace(str, ".", "_", -1)
+	str = strings.Replace(str, "+", "_", -1)
+	str = strings.Replace(str, "-", "_", -1)
 
+	return str
+}
+
+func replaceSuffixes(str string) string {
+	if strings.HasSuffix(str, "-") {
+		str = strings.TrimSuffix(str, "-")
+		str = str + "_Minus"
+	}
+
+	if strings.HasSuffix(str, "+") {
+		str = strings.TrimSuffix(str, "+")
+		str = str + "_Plus"
+	}
 	return str
 }

--- a/internal/utils/dbidentifier/dbidentifier_test.go
+++ b/internal/utils/dbidentifier/dbidentifier_test.go
@@ -1,8 +1,9 @@
 package dbidentifier
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestToGoIdentifier(t *testing.T) {
@@ -22,4 +23,7 @@ func TestToGoIdentifier(t *testing.T) {
 	require.Equal(t, ToGoIdentifier("My_Table"), "MyTable")
 	require.Equal(t, ToGoIdentifier("My Table"), "MyTable")
 	require.Equal(t, ToGoIdentifier("My-Table"), "MyTable")
+
+	require.Equal(t, ToGoIdentifier("My-Table+"), "MyTablePlus")
+	require.Equal(t, ToGoIdentifier("My-Table-"), "MyTableMinus")
 }


### PR DESCRIPTION
This change improves handling of db identifiers:
- it handles "+" in identifiers
- it improves handling of identifiers that end with plus or minus like "Entity+" and "Entity-" as enum values that would otherwise produce conflicting values