### PR TITLE
ON CONFLICT DO NOTHING without a conflict target is valid SQL

### DIFF
--- a/postgres/clause.go
+++ b/postgres/clause.go
@@ -44,7 +44,7 @@ func (o *onConflictClause) DO_UPDATE(action conflictAction) InsertStatement {
 }
 
 func (o *onConflictClause) Serialize(statementType jet.StatementType, out *jet.SQLBuilder, options ...jet.SerializeOption) {
-	if len(o.indexExpressions) == 0 && o.constraint == "" {
+	if len(o.indexExpressions) == 0 && o.constraint == "" && o.do != jet.Keyword("DO NOTHING") {
 		return
 	}
 

--- a/postgres/clause_test.go
+++ b/postgres/clause_test.go
@@ -8,7 +8,8 @@ func TestOnConflict(t *testing.T) {
 
 	onConflict := &onConflictClause{}
 	onConflict.DO_NOTHING()
-	assertClauseSerialize(t, onConflict, "")
+	assertClauseSerialize(t, onConflict, `
+ON CONFLICT DO NOTHING`)
 
 	onConflict = &onConflictClause{indexExpressions: ColumnList{table1ColBool}}
 	onConflict.DO_NOTHING()


### PR DESCRIPTION
ON CONFLICT DO NOTHING without a conflict target is valid SQL according to Postgres.

https://www.postgresql.org/docs/15/sql-insert.html#SQL-ON-CONFLICT