### PR TITLE
Export BinaryOperator function

### DIFF
--- a/internal/jet/operators.go
+++ b/internal/jet/operators.go
@@ -188,3 +188,7 @@ func (c *caseOperatorImpl) serialize(statement StatementType, out *SQLBuilder, o
 func DISTINCT(expr Expression) Expression {
 	return newPrefixOperatorExpression(expr, "DISTINCT")
 }
+
+func BinaryOperator(lhs Expression, rhs Expression, operator string) Expression {
+	return NewBinaryOperatorExpression(lhs, rhs, operator)
+}

--- a/mysql/expressions.go
+++ b/mysql/expressions.go
@@ -93,3 +93,6 @@ var Func = jet.Func
 
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue
+
+// BinaryOperator can be used to use custom or unsupported operators that take two operands.
+var BinaryOperator = jet.BinaryOperator

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -142,3 +142,6 @@ var Func = jet.Func
 
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue
+
+// BinaryOperator can be used to use custom or unsupported operators that take two operands.
+var BinaryOperator = jet.BinaryOperator

--- a/sqlite/expressions.go
+++ b/sqlite/expressions.go
@@ -96,3 +96,6 @@ var Func = jet.Func
 
 // NewEnumValue creates new named enum value
 var NewEnumValue = jet.NewEnumValue
+
+// BinaryOperator can be used to use custom or unsupported operators that take two operands.
+var BinaryOperator = jet.BinaryOperator


### PR DESCRIPTION
This PR exports a `BinaryOperator` function that is similar in spirit to `jet.Func`, but for custom/unsupported operators rather than for functions. See https://github.com/go-jet/jet/issues/338

This is kind of a proof-of-concept PR; maybe this should have tests? It should probably have docs as well.

Maybe there should also be a `UnaryOperator` and a `TernaryOperator` but at least from my perspective I don't foresee a huge need for those.