### PR TITLE
feat: export CustomExpression and Token for dialects to use 

### DIFF
--- a/internal/jet/expression.go
+++ b/internal/jet/expression.go
@@ -278,7 +278,7 @@ type customExpression struct {
 	parts []Serializer
 }
 
-func newCustomExpression(parts ...Serializer) Expression {
+func NewCustomExpression(parts ...Serializer) Expression {
 	ret := customExpression{
 		parts: parts,
 	}

--- a/internal/jet/expression.go
+++ b/internal/jet/expression.go
@@ -278,7 +278,7 @@ type customExpression struct {
 	parts []Serializer
 }
 
-func NewCustomExpression(parts ...Serializer) Expression {
+func CustomExpression(parts ...Serializer) Expression {
 	ret := customExpression{
 		parts: parts,
 	}

--- a/internal/jet/func_expression.go
+++ b/internal/jet/func_expression.go
@@ -548,7 +548,7 @@ func TO_TIMESTAMP(timestampzStr, format StringExpression) TimestampzExpression {
 
 // EXTRACT extracts time component from time expression
 func EXTRACT(field string, from Expression) Expression {
-	return newCustomExpression(Token("EXTRACT("), Token(field), Token("FROM"), from, Token(")"))
+	return NewCustomExpression(Token("EXTRACT("), Token(field), Token("FROM"), from, Token(")"))
 }
 
 // CURRENT_DATE returns current date

--- a/internal/jet/func_expression.go
+++ b/internal/jet/func_expression.go
@@ -548,7 +548,7 @@ func TO_TIMESTAMP(timestampzStr, format StringExpression) TimestampzExpression {
 
 // EXTRACT extracts time component from time expression
 func EXTRACT(field string, from Expression) Expression {
-	return NewCustomExpression(Token("EXTRACT("), Token(field), Token("FROM"), from, Token(")"))
+	return CustomExpression(Token("EXTRACT("), Token(field), Token("FROM"), from, Token(")"))
 }
 
 // CURRENT_DATE returns current date

--- a/internal/jet/group_by_clause.go
+++ b/internal/jet/group_by_clause.go
@@ -35,7 +35,7 @@ func GROUPING(expressions ...Expression) IntegerExpression {
 // WITH_ROLLUP operator is used with the GROUP BY clause to generate all prefixes of a group of columns including the empty list.
 // It creates extra rows in the result set that represent the subtotal values for each combination of columns.
 func WITH_ROLLUP(expressions ...Expression) GroupByClause {
-	return newCustomExpression(
+	return NewCustomExpression(
 		parametersSerializer(expressions), Token("WITH ROLLUP"),
 	)
 }

--- a/internal/jet/group_by_clause.go
+++ b/internal/jet/group_by_clause.go
@@ -35,7 +35,7 @@ func GROUPING(expressions ...Expression) IntegerExpression {
 // WITH_ROLLUP operator is used with the GROUP BY clause to generate all prefixes of a group of columns including the empty list.
 // It creates extra rows in the result set that represent the subtotal values for each combination of columns.
 func WITH_ROLLUP(expressions ...Expression) GroupByClause {
-	return NewCustomExpression(
+	return CustomExpression(
 		parametersSerializer(expressions), Token("WITH ROLLUP"),
 	)
 }

--- a/mysql/expressions.go
+++ b/mysql/expressions.go
@@ -70,6 +70,12 @@ var DateTimeExp = jet.TimestampExp
 // Does not add sql cast to generated sql builder output.
 var TimestampExp = jet.TimestampExp
 
+// CustomExpression is used to define custom expressions.
+var CustomExpression = jet.CustomExpression
+
+// Token is used to define custom token in a custom expression.
+type Token = jet.Token
+
 // RawArgs is type used to pass optional arguments to Raw method
 type RawArgs = map[string]interface{}
 

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -111,6 +111,12 @@ var (
 	TstzRangeExp = jet.TstzRangeExp
 )
 
+// CustomExpression is used to define custom expressions.
+var CustomExpression = jet.CustomExpression
+
+// Token is used to define custom token in a custom expression.
+type Token = jet.Token
+
 // RawArgs is type used to pass optional arguments to Raw method
 type RawArgs = map[string]interface{}
 

--- a/sqlite/expressions.go
+++ b/sqlite/expressions.go
@@ -73,6 +73,12 @@ var DateTimeExp = jet.TimestampExp
 // Does not add sql cast to generated sql builder output.
 var TimestampExp = jet.TimestampExp
 
+// CustomExpression is used to define custom expressions.
+var CustomExpression = jet.CustomExpression
+
+// Token is used to define custom token in a custom expression.
+type Token = jet.Token
+
 // RawArgs is type used to pass optional arguments to Raw method
 type RawArgs = map[string]interface{}
 


### PR DESCRIPTION
Hey Goran, nice lib! I hope you'll consider allowing a change like this. Doing this allows a particular SQL dialect to implement additional operators/expressions that may deviate from default SQL.

Background: I'm playing with a dialect that supports this notation:

  SELECT * FROM table WHERE any_match ( x -> x IS NOT NULL, someField )

That'd be something I'd want to implement just for that dialect (in its own dialect package in jet) but for that I need access to the serializer method. 

This pull request has no functional changes, just a refactoring to expose `jet.newCustomExpression` to other jet packages. 