### PR TITLE
Add HasDefault column metadata

### DIFF
--- a/generator/metadata/column_meta_data.go
+++ b/generator/metadata/column_meta_data.go
@@ -10,6 +10,7 @@ type Column struct {
 	IsPrimaryKey bool
 	IsNullable   bool
 	IsGenerated  bool
+	HasDefault   bool
 	DataType     DataType
 	Comment      string
 }

--- a/generator/mysql/query_set.go
+++ b/generator/mysql/query_set.go
@@ -18,6 +18,7 @@ func (m mySqlQuerySet) GetTablesMetaData(db *sql.DB, schemaName string, tableTyp
 SELECT
 		t.table_name as "table.name",
 		col.COLUMN_NAME AS "column.Name",
+		col.COLUMN_DEFAULT IS NOT NULL as "column.HasDefault",
 		col.IS_NULLABLE = "YES" AS "column.IsNullable",
 		col.COLUMN_COMMENT AS "column.Comment",
 		COALESCE(pk.IsPrimaryKey, 0) AS "column.IsPrimaryKey",

--- a/generator/postgres/query_set.go
+++ b/generator/postgres/query_set.go
@@ -64,6 +64,7 @@ select
     ) as "column.IsPrimaryKey",
     not attr.attnotnull as "column.isNullable",
     attr.attgenerated = 's' as "column.isGenerated",
+    attr.atthasdef as "column.hasDefault",
     (case tp.typtype 
         when 'b' then 'base'
         when 'd' then 'base'

--- a/tests/postgres/generator_template_test.go
+++ b/tests/postgres/generator_template_test.go
@@ -3,6 +3,9 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"path"
+	"testing"
+
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/generator/postgres"
 	"github.com/go-jet/jet/v2/generator/template"
@@ -13,8 +16,6 @@ import (
 	"github.com/go-jet/jet/v2/tests/dbconfig"
 	file2 "github.com/go-jet/jet/v2/tests/internal/utils/file"
 	"github.com/stretchr/testify/require"
-	"path"
-	"testing"
 )
 
 const tempTestDir = "./.tempTestDir"


### PR DESCRIPTION
Adds a new "HasDefault" field to the column metadata. The field value is `true` if the column has a default value and false otherwise.

Added integration tests for postgres, mysql, and sqlite that assert the value is set as expected. Results are specific to each database.