### PR TITLE
Add Postgres GENERATE_SERIES function

### DIFF
--- a/postgres/functions.go
+++ b/postgres/functions.go
@@ -342,6 +342,15 @@ func DATE_TRUNC(field unit, source Expression, timezone ...string) TimestampExpr
 	return jet.NewTimestampFunc("DATE_TRUNC", jet.FixedLiteral(unitToString(field)), source)
 }
 
+// GENERATE_SERIES generates a series of values from start to stop, with a step size of step.
+func GENERATE_SERIES(start Expression, stop Expression, step ...Expression) Expression {
+	if len(step) > 0 {
+		return jet.NewFunc("GENERATE_SERIES", []Expression{start, stop, step[0]}, nil)
+	}
+
+	return jet.NewFunc("GENERATE_SERIES", []Expression{start, stop}, nil)
+}
+
 // --------------- Conditional Expressions Functions -------------//
 
 // COALESCE function returns the first of its arguments that is not null.

--- a/postgres/functions_test.go
+++ b/postgres/functions_test.go
@@ -21,3 +21,16 @@ func TestDATE_TRUNC(t *testing.T) {
 		"DATE_TRUNC('DAY', NOW() + INTERVAL '1 HOUR', 'Australia/Sydney')",
 	)
 }
+
+func TestGENERATE_SERIES(t *testing.T) {
+	assertSerialize(
+		t,
+		GENERATE_SERIES(NOW(), NOW().ADD(INTERVAL(10, DAY))),
+		"GENERATE_SERIES(NOW(), NOW() + INTERVAL '10 DAY')",
+	)
+	assertSerialize(
+		t,
+		GENERATE_SERIES(NOW(), NOW().ADD(INTERVAL(10, DAY)), INTERVAL(2, DAY)),
+		"GENERATE_SERIES(NOW(), NOW() + INTERVAL '10 DAY', INTERVAL '2 DAY')",
+	)
+}


### PR DESCRIPTION
Adds GENERATE_SERIES function https://www.postgresql.org/docs/current/functions-srf.html
I could also add the GENERATE_SUBSCRIPTS function but it has to wait for array expressions https://github.com/go-jet/jet/pull/380.