### PR TITLE
Fix generating schema fails due to column name conflicts

### DIFF
--- a/generator/template/sql_builder_template.go
+++ b/generator/template/sql_builder_template.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/internal/utils/dbidentifier"
 	"path"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -134,10 +135,19 @@ type TableSQLBuilderColumn struct {
 	Type string
 }
 
+var reservedKeywords = []string{"TableName", "Table", "SchemaName", "Alias", "AllColumns", "MutableColumns"}
+
+func renameIfReserved(name string) string {
+	if slices.Contains(reservedKeywords, name) {
+		return name + "_"
+	}
+	return name
+}
+
 // DefaultTableSQLBuilderColumn returns default implementation of TableSQLBuilderColumn
 func DefaultTableSQLBuilderColumn(columnMetaData metadata.Column) TableSQLBuilderColumn {
 	return TableSQLBuilderColumn{
-		Name: dbidentifier.ToGoIdentifier(columnMetaData.Name),
+		Name: renameIfReserved(dbidentifier.ToGoIdentifier(columnMetaData.Name)),
 		Type: getSqlBuilderColumnType(columnMetaData),
 	}
 }

--- a/generator/template/sql_builder_template_test.go
+++ b/generator/template/sql_builder_template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -8,4 +9,28 @@ import (
 func TestToGoEnumValueIdentifier(t *testing.T) {
 	require.Equal(t, defaultEnumValueName("enum_name", "enum_value"), "EnumValue")
 	require.Equal(t, defaultEnumValueName("NumEnum", "100"), "NumEnum100")
+}
+
+func TestColumnRenameReserved(t *testing.T) {
+	tests := []struct {
+		col  string
+		want string
+	}{
+		{col: "TableName", want: "TableName_"},
+		{col: "Table", want: "Table_"},
+		{col: "SchemaName", want: "SchemaName_"},
+		{col: "Alias", want: "Alias_"},
+		{col: "AllColumns", want: "AllColumns_"},
+		{col: "MutableColumns", want: "MutableColumns_"},
+		{col: "OtherColumn", want: "OtherColumn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.col, func(t *testing.T) {
+			builder := DefaultTableSQLBuilderColumn(metadata.Column{
+				Name: tt.col,
+			})
+			require.Equal(t, builder.Name, tt.want)
+		})
+	}
 }


### PR DESCRIPTION
fixes #408 

- Added a function to rename a column if it conflicts with reserved keywords. 

- Updated sql_builder_template to check if column is in a conflict with reserved key words

- Added unit tests. 

Thank you for this awesome project! Let me know if there is anything I can add or change. 