### PR TITLE
Fixed local test suite by syncing MySQL and MariaDB versions from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
     docker:
       # specify the version
       - image: cimg/go:1.22.8
+
+      # Please keep the version in sync with test/docker-compose.yaml
       - image: cimg/postgres:14.10
         environment:
           POSTGRES_USER: jet
@@ -16,6 +18,7 @@ jobs:
           POSTGRES_DB: jetdb
           PGPORT: 50901
 
+      # Please keep the version in sync with test/docker-compose.yaml
       - image: circleci/mysql:8.0.27
         command: [ --default-authentication-plugin=mysql_native_password ]
         environment:
@@ -25,6 +28,7 @@ jobs:
           MYSQL_PASSWORD: jet
           MYSQL_TCP_PORT: 50902
 
+      # Please keep the version in sync with test/docker-compose.yaml
       - image: circleci/mariadb:10.3
         command: [ '--default-authentication-plugin=mysql_native_password', '--port=50903' ]
         environment:
@@ -33,6 +37,7 @@ jobs:
           MYSQL_USER: jet
           MYSQL_PASSWORD: jet
 
+      # Please keep the version in sync with test/docker-compose.yaml
       - image: cockroachdb/cockroach-unstable:v23.1.0-rc.2
         command: ['start-single-node', '--accept-sql-without-tls']
         environment:

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./testdata/init/postgres:/docker-entrypoint-initdb.d
 
   mysql:
-    image: mysql:8.0
+    image: mysql:8.0.27
     command: ['--default-authentication-plugin=mysql_native_password', '--log_bin_trust_function_creators=1']
     restart: always
     environment:
@@ -26,7 +26,7 @@ services:
       - ./testdata/init/mysql:/docker-entrypoint-initdb.d
 
   mariadb:
-    image: mariadb:10.3.32
+    image: mariadb:10.3
     command: ['--default-authentication-plugin=mysql_native_password', '--log_bin_trust_function_creators=1']
     restart: always
     environment:


### PR DESCRIPTION
### Goal
MySQL and MariaDB versions are not the same between `.circleci/config.yml` and `tests/docker-compose.yaml`, and as such, the local test suite fails on the `master` branch whereas it passes in CircleCI.

I've synced versions of MySQL and MariaDB databases so that local tests work correctly.
Please see Issue #423 for more context.