### PR TITLE
remove redundant call in filesys RemoveDir

### DIFF
--- a/generator/template/process.go
+++ b/generator/template/process.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/go-jet/jet/v2/internal/utils/filesys"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/go-jet/jet/v2/internal/utils/filesys"
 
 	"github.com/go-jet/jet/v2/generator/metadata"
 	"github.com/go-jet/jet/v2/internal/jet"
@@ -24,12 +26,11 @@ func ProcessSchema(dirPath string, schemaMetaData metadata.Schema, generatorTemp
 
 	fmt.Println("Destination directory:", schemaPath)
 	fmt.Println("Cleaning up destination directory...")
-	err := filesys.RemoveDir(schemaPath)
-	if err != nil {
+	if err := os.RemoveAll(schemaPath); err != nil {
 		return errors.New("failed to cleanup generated files")
 	}
 
-	err = processModel(schemaPath, schemaMetaData, schemaTemplate)
+	err := processModel(schemaPath, schemaMetaData, schemaTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to generate model types: %w", err)
 	}

--- a/internal/utils/filesys/filesys.go
+++ b/internal/utils/filesys/filesys.go
@@ -56,24 +56,3 @@ func EnsureDirPathExist(dirPath string) error {
 
 	return nil
 }
-
-// RemoveDir deletes everything at folder dir.
-func RemoveDir(dir string) error {
-	if err := os.RemoveAll(dir); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DirExists checks if folder at path exist.
-func DirExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, err
-}

--- a/internal/utils/filesys/filesys.go
+++ b/internal/utils/filesys/filesys.go
@@ -59,18 +59,8 @@ func EnsureDirPathExist(dirPath string) error {
 
 // RemoveDir deletes everything at folder dir.
 func RemoveDir(dir string) error {
-	exist, err := DirExists(dir)
-
-	if err != nil {
+	if err := os.RemoveAll(dir); err != nil {
 		return err
-	}
-
-	if exist {
-		err := os.RemoveAll(dir)
-
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
RemoveAll removes path and any children it contains. It removes everything it can but returns the first error it encounters. If the path does not exist, RemoveAll returns nil (no error). If there is an error, it will be of type [*PathError].

So, there is no need to check whether the directory exists.