### PR TITLE
fix: quote identifiers starting with numbers

### DIFF
--- a/internal/jet/sql_builder.go
+++ b/internal/jet/sql_builder.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"database/sql/driver"
 	"fmt"
-	"github.com/go-jet/jet/v2/internal/3rdparty/pq"
-	"github.com/go-jet/jet/v2/internal/utils/is"
-	"github.com/google/uuid"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/go-jet/jet/v2/internal/3rdparty/pq"
+	"github.com/go-jet/jet/v2/internal/utils/is"
+	"github.com/google/uuid"
 )
 
 // SQLBuilder generates output SQL
@@ -302,9 +303,18 @@ func integerTypesToString(value interface{}) string {
 }
 
 func shouldQuoteIdentifier(identifier string) bool {
+	if len(identifier) == 0 {
+		return true
+	}
+
 	_, err := strconv.ParseInt(identifier, 10, 64)
 
 	if err == nil { // if it is a number we should quote it
+		return true
+	}
+
+	firstChar := rune(identifier[0])
+	if unicode.IsNumber(firstChar) {
 		return true
 	}
 

--- a/internal/jet/sql_builder_test.go
+++ b/internal/jet/sql_builder_test.go
@@ -1,10 +1,11 @@
 package jet
 
 import (
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArgToString(t *testing.T) {
@@ -58,4 +59,6 @@ func TestShouldQuote(t *testing.T) {
 	require.Equal(t, shouldQuoteIdentifier("abc_123"), false)
 	require.Equal(t, shouldQuoteIdentifier("Abc_123"), true)
 	require.Equal(t, shouldQuoteIdentifier("ǄƜĐǶ"), true)
+	require.Equal(t, shouldQuoteIdentifier("1test"), true)
+	require.Equal(t, shouldQuoteIdentifier(""), true)
 }


### PR DESCRIPTION
**Problem:** Schema names starting with digits (e.g., `1test`) were not being properly quoted, generating invalid SQL like `FROM 1test.users` instead of `FROM "1test".users`.

**Solution:** Enhanced `shouldQuoteIdentifier()` function to detect identifiers starting with digits using `unicode.IsNumber()` and added empty string validation to prevent panics.

Closes: #510