### PR TITLE
feat: add returning to mysql

### DIFF
--- a/mysql/delete_statement.go
+++ b/mysql/delete_statement.go
@@ -12,16 +12,18 @@ type DeleteStatement interface {
 	WHERE(expression BoolExpression) DeleteStatement
 	ORDER_BY(orderByClauses ...OrderByClause) DeleteStatement
 	LIMIT(limit int64) DeleteStatement
+	RETURNING(projections ...jet.Projection) DeleteStatement
 }
 
 type deleteStatementImpl struct {
 	jet.SerializerStatement
 
-	Delete  jet.ClauseDelete
-	Using   jet.ClauseFrom
-	Where   jet.ClauseWhere
-	OrderBy jet.ClauseOrderBy
-	Limit   jet.ClauseLimit
+	Delete    jet.ClauseDelete
+	Using     jet.ClauseFrom
+	Where     jet.ClauseWhere
+	OrderBy   jet.ClauseOrderBy
+	Limit     jet.ClauseLimit
+	Returning jet.ClauseReturning
 }
 
 func newDeleteStatement(table Table) DeleteStatement {
@@ -32,6 +34,7 @@ func newDeleteStatement(table Table) DeleteStatement {
 		&newDelete.Where,
 		&newDelete.OrderBy,
 		&newDelete.Limit,
+		&newDelete.Returning,
 	)
 
 	newDelete.Delete.Table = table
@@ -64,5 +67,10 @@ func (d *deleteStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) DeleteSt
 
 func (d *deleteStatementImpl) LIMIT(limit int64) DeleteStatement {
 	d.Limit.Count = limit
+	return d
+}
+
+func (d *deleteStatementImpl) RETURNING(projections ...jet.Projection) DeleteStatement {
+	d.Returning.ProjectionList = projections
 	return d
 }

--- a/mysql/delete_statement_test.go
+++ b/mysql/delete_statement_test.go
@@ -24,3 +24,11 @@ ORDER BY table1.col1
 LIMIT ?;
 `, int64(1), int64(1))
 }
+
+func TestDeleteWithWhereAndReturning(t *testing.T) {
+	assertStatementSql(t, table1.DELETE().WHERE(table1Col1.EQ(Int(1))).RETURNING(table1Col1), `
+DELETE FROM db.table1
+WHERE table1.col1 = ?
+RETURNING table1.col1 AS "table1.col1";
+`, int64(1))
+}

--- a/mysql/dialect.go
+++ b/mysql/dialect.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"encoding/hex"
 	"fmt"
+
 	"github.com/go-jet/jet/v2/internal/jet"
 )
 
@@ -437,6 +438,7 @@ var reservedWords = []string{
 	"RESIGNAL",
 	"RESTRICT",
 	"RETURN",
+	"RETURNING",
 	"REVOKE",
 	"RIGHT",
 	"RLIKE",

--- a/mysql/insert_statement.go
+++ b/mysql/insert_statement.go
@@ -19,6 +19,8 @@ type InsertStatement interface {
 	ON_DUPLICATE_KEY_UPDATE(assigments ...ColumnAssigment) InsertStatement
 
 	QUERY(selectStatement SelectStatement) InsertStatement
+
+	RETURNING(projections ...Projection) InsertStatement
 }
 
 func newInsertStatement(table Table, columns []jet.Column) InsertStatement {
@@ -27,6 +29,7 @@ func newInsertStatement(table Table, columns []jet.Column) InsertStatement {
 		&newInsert.Insert,
 		&newInsert.ValuesQuery,
 		&newInsert.OnDuplicateKey,
+		&newInsert.Returning,
 	)
 
 	newInsert.Insert.Table = table
@@ -40,6 +43,7 @@ type insertStatementImpl struct {
 
 	Insert         jet.ClauseInsert
 	ValuesQuery    jet.ClauseValuesQuery
+	Returning      jet.ClauseReturning
 	OnDuplicateKey onDuplicateKeyUpdateClause
 }
 
@@ -61,6 +65,11 @@ func (is *insertStatementImpl) MODEL(data interface{}) InsertStatement {
 func (is *insertStatementImpl) MODELS(data interface{}) InsertStatement {
 	is.ValuesQuery.Rows = append(is.ValuesQuery.Rows, jet.UnwindRowsFromModels(is.Insert.GetColumns(), data)...)
 	return is
+}
+
+func (i *insertStatementImpl) RETURNING(projections ...jet.Projection) InsertStatement {
+	i.Returning.ProjectionList = projections
+	return i
 }
 
 func (is *insertStatementImpl) AS_NEW() InsertStatement {

--- a/mysql/insert_statement_test.go
+++ b/mysql/insert_statement_test.go
@@ -1,9 +1,10 @@
 package mysql
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidInsert(t *testing.T) {
@@ -21,6 +22,14 @@ func TestInsertSingleValue(t *testing.T) {
 	assertStatementSql(t, table1.INSERT(table1Col1).VALUES(1), `
 INSERT INTO db.table1 (col1)
 VALUES (?);
+`, int(1))
+}
+
+func TestInsertWithReturing(t *testing.T) {
+	assertStatementSql(t, table1.INSERT(table1Col1).VALUES(1).RETURNING(table1Col1), `
+INSERT INTO db.table1 (col1)
+VALUES (?)
+RETURNING table1.col1 AS "table1.col1";
 `, int(1))
 }
 


### PR DESCRIPTION
MariaDB support returning since 10.5.0:
* https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning
* https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete