### PR TITLE
Add second parameter to obj_description calls

### DIFF
--- a/generator/postgres/query_set.go
+++ b/generator/postgres/query_set.go
@@ -14,7 +14,7 @@ type postgresQuerySet struct{}
 
 func (p postgresQuerySet) GetTablesMetaData(db *sql.DB, schemaName string, tableType metadata.TableType) ([]metadata.Table, error) {
 	query := `
-SELECT table_name as "table.name", obj_description((quote_ident(table_schema)||'.'||quote_ident(table_name))::regclass) as "table.comment"
+SELECT table_name as "table.name", obj_description((quote_ident(table_schema)||'.'||quote_ident(table_name))::regclass, 'pg_class') as "table.comment"
 FROM information_schema.tables
 WHERE table_schema = $1 and table_type = $2
 ORDER BY table_name;
@@ -105,7 +105,7 @@ order by
 func (p postgresQuerySet) GetEnumsMetaData(db *sql.DB, schemaName string) ([]metadata.Enum, error) {
 	query := `
 SELECT t.typname as "enum.name",  
-	   obj_description(t.oid) as "enum.comment",
+	   obj_description(t.oid, 'pg_class') as "enum.comment",
        e.enumlabel as "values"
 FROM pg_catalog.pg_type t 
    JOIN pg_catalog.pg_enum e on t.oid = e.enumtypid  


### PR DESCRIPTION
The single parameter form of obj_description is deprecated:
> obj_description ( object oid ) → text
> Returns the comment for a database object specified by its OID alone. This is deprecated since there is no guarantee that OIDs are unique across different system catalogs; therefore, the wrong comment might be returned.

https://www.postgresql.org/docs/current/functions-info.html

(It has been deprecated since at least Postgres 8.0: https://www.postgresql.org/docs/8.0/functions-info.html)

Some databases (like Materialize) only support the two-parameter form, so I'd like to merge this for compatibility there, as well as safety even in Postgres etc.