### PR TITLE
[pgx] fix(qrm): database errors swallowed as ErrNoRows on pgx v5.9.0+

### DIFF
--- a/qrm/qrm_pgx_v5.go
+++ b/qrm/qrm_pgx_v5.go
@@ -132,7 +132,12 @@ func queryToSlicePgxV5(ctx context.Context, db QueryablePgxV5, query string, arg
 	if err != nil {
 		return
 	}
-	defer rows.Close()
+	defer func() {
+		rows.Close()
+		if err == nil {
+			err = rows.Err()
+		}
+	}()
 
 	scanContext, err := NewScanContextPGXv5(rows)
 
@@ -162,9 +167,8 @@ func queryToSlicePgxV5(ctx context.Context, db QueryablePgxV5, query string, arg
 		}
 	}
 
-	rows.Close()
-
-	return scanContext.rowNum, rows.Err()
+	rowsProcessed = scanContext.rowNum
+	return
 }
 
 func queryJsonPgxV5(ctx context.Context, db QueryablePgxV5, query string, args []interface{}, destPtr interface{}) (rowsProcessed int64, err error) {


### PR DESCRIPTION
_Note that this PR targets the `pgx` branch of go-jet._

Starting from version 5.9.0, pgx skips the `DescribePortal` round-trip for cached prepared statements[0]. When a query fails before returning any data (e.g. unique or FK constraint violation), the server never sends `RowDescription`, so `rows.FieldDescriptions()` returns nil. Then, `queryToSlicePgxV5` builds a scan context from "nil" field descriptions, gets `len == 0`, and returns `(0, nil)` without ever calling `rows.Err()`, leading callers to see `ErrNoRows` instead of the actual database error.

This commit fixes this issue by always checking for `rows.Err()` before returning.

[0] https://github.com/jackc/pgx/blob/master/CHANGELOG.md#590-march-21-2026