### PR TITLE
Expose the Snaker configuration

### DIFF
--- a/internal/3rdparty/snaker/snaker.go
+++ b/internal/3rdparty/snaker/snaker.go
@@ -8,6 +8,69 @@ import (
 	"unicode"
 )
 
+// Config holds the configuration settings for the Snaker behavior.
+type Config struct {
+	// commonInitialisms, taken from
+	// https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L731
+	Initialisms map[string]bool
+
+	// Add exceptions here for things that are not automatically convertable
+	SnakeToCamelExceptions map[string]string
+}
+
+
+// GlobalConfig is the package-wide configuration
+// This variable is not thread safe.
+var GlobalConfig = Config{
+	Initialisms: map[string]bool{
+		"ACL":   true,
+		"API":   true,
+		"ASCII": true,
+		"CPU":   true,
+		"CSS":   true,
+		"DNS":   true,
+		"EOF":   true,
+		"ETA":   true,
+		"GPU":   true,
+		"GUID":  true,
+		"HTML":  true,
+		"HTTP":  true,
+		"HTTPS": true,
+		"ID":    true,
+		"IP":    true,
+		"JSON":  true,
+		"LHS":   true,
+		"OS":    true,
+		"QPS":   true,
+		"RAM":   true,
+		"RHS":   true,
+		"RPC":   true,
+		"SLA":   true,
+		"SMTP":  true,
+		"SQL":   true,
+		"SSH":   true,
+		"TCP":   true,
+		"TLS":   true,
+		"TTL":   true,
+		"UDP":   true,
+		"UI":    true,
+		"UID":   true,
+		"UUID":  true,
+		"URI":   true,
+		"URL":   true,
+		"UTF8":  true,
+		"VM":    true,
+		"XML":   true,
+		"XMPP":  true,
+		"XSRF":  true,
+		"XSS":   true,
+		"OAuth": true,
+	},
+	SnakeToCamelExceptions: map[string]string{
+		"oauth": "OAuth",
+	},
+}
+
 // CamelToSnake converts a given string to snake case
 func CamelToSnake(s string) string {
 	var result string
@@ -64,13 +127,13 @@ func snakeToCamel(s string, upperCase bool) string {
 	words := strings.Split(s, "_")
 
 	for i, word := range words {
-		if exception := snakeToCamelExceptions[word]; len(exception) > 0 {
+		if exception := GlobalConfig.SnakeToCamelExceptions[word]; len(exception) > 0 {
 			result += exception
 			continue
 		}
 
 		if upperCase || i > 0 {
-			if upper := strings.ToUpper(word); commonInitialisms[upper] {
+			if upper := strings.ToUpper(word); GlobalConfig.Initialisms[upper] {
 				result += upper
 				continue
 			}
@@ -91,7 +154,7 @@ func startsWithInitialism(s string) string {
 	var initialism string
 	// the longest initialism is 5 char, the shortest 2
 	for i := 1; i <= 5; i++ {
-		if len(s) > i-1 && commonInitialisms[s[:i]] {
+		if len(s) > i-1 && GlobalConfig.Initialisms[s[:i]] {
 			initialism = s[:i]
 		}
 	}
@@ -123,56 +186,4 @@ func camelizeWord(word string, force bool) string {
 	}
 
 	return string(runes)
-}
-
-// commonInitialisms, taken from
-// https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L731
-var commonInitialisms = map[string]bool{
-	"ACL":   true,
-	"API":   true,
-	"ASCII": true,
-	"CPU":   true,
-	"CSS":   true,
-	"DNS":   true,
-	"EOF":   true,
-	"ETA":   true,
-	"GPU":   true,
-	"GUID":  true,
-	"HTML":  true,
-	"HTTP":  true,
-	"HTTPS": true,
-	"ID":    true,
-	"IP":    true,
-	"JSON":  true,
-	"LHS":   true,
-	"OS":    true,
-	"QPS":   true,
-	"RAM":   true,
-	"RHS":   true,
-	"RPC":   true,
-	"SLA":   true,
-	"SMTP":  true,
-	"SQL":   true,
-	"SSH":   true,
-	"TCP":   true,
-	"TLS":   true,
-	"TTL":   true,
-	"UDP":   true,
-	"UI":    true,
-	"UID":   true,
-	"UUID":  true,
-	"URI":   true,
-	"URL":   true,
-	"UTF8":  true,
-	"VM":    true,
-	"XML":   true,
-	"XMPP":  true,
-	"XSRF":  true,
-	"XSS":   true,
-	"OAuth": true,
-}
-
-// add exceptions here for things that are not automatically convertable
-var snakeToCamelExceptions = map[string]string{
-	"oauth": "OAuth",
 }

--- a/jet.go
+++ b/jet.go
@@ -1,0 +1,14 @@
+package jet
+
+import "github.com/go-jet/jet/v2/internal/3rdparty/snaker"
+
+// Config holds the configuration settings for Jet
+type Config struct {
+	Snaker *snaker.Config
+}
+
+// GlobalConfig is the package-wide configuration
+// This variable is not thread safe, and it should be modified only once, for instance, during application initialization.
+var GlobalConfig = Config{
+	Snaker: &snaker.GlobalConfig,
+}


### PR DESCRIPTION
This exposes the Snaker configuration, providing a simple way to customize the initialisms.

I made it to workaround https://github.com/go-jet/jet/issues/587, because as far as my understanding goes, alternative ways to fix it would require more important, and probably breaking changes.

The drawback is that since Snaker is used both during the code generation phase and runtime, the config needs to be set consistently in both cases.

As for the config pattern, since `snaker` is private, I opted to expose it via a global configuration in the `jet` package itself, mostly because it's the least disruptive design. However we could possibly make it public instead, that would be more consistent with what already exists via `qrm.GlobalConfig`.

What do you think?