### PR TITLE
Added an optional struct tag to fix mapping errors

### DIFF
--- a/generator/template/model_template.go
+++ b/generator/template/model_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -211,6 +212,26 @@ func (f TableModelField) TagsString() string {
 	}
 
 	return fmt.Sprintf("`%s`", strings.Join(f.Tags, " "))
+}
+
+// addColumnTag adds the column tag to ensure that the right column is used at runtime,
+// if the name of the field has been changed in UseField.
+func addColumnTag(field TableModelField, columnMetaData metadata.Column) TableModelField {
+	if field.Name == DefaultTableModelField(columnMetaData).Name {
+		// No change in name: don't need the column tag
+		return field
+	}
+
+	columnTagExists := slices.ContainsFunc(field.Tags, func(tag string) bool {
+		return strings.HasPrefix(tag, "column:")
+	})
+	if columnTagExists {
+		// A conflicting tag already exists: keep it as-it-is
+		return field
+	}
+
+	field.Tags = append(field.Tags, fmt.Sprintf("column:%q", columnMetaData.Name))
+	return field
 }
 
 // Type represents type of the struct field

--- a/generator/template/model_template_test.go
+++ b/generator/template/model_template_test.go
@@ -45,6 +45,31 @@ func TestTableModelField(t *testing.T) {
 	})
 }
 
+func TestAddColumnTag(t *testing.T) {
+	t.Run("default name", func(t *testing.T) {
+		field := TableModelField{Name: "FooID"}
+		column := metadata.Column{Name: "foo_id"}
+		resultField := addColumnTag(field, column)
+		require.NotContains(t, resultField.Tags, `column:"foo_id"`)
+	})
+	t.Run("custom name", func(t *testing.T) {
+		field := TableModelField{Name: "CustomINITIALISM"}
+		column := metadata.Column{Name: "custom_initialism"}
+		resultField := addColumnTag(field, column)
+		require.Contains(t, resultField.Tags, `column:"custom_initialism"`)
+	})
+	t.Run("custom name and tag", func(t *testing.T) {
+		field := TableModelField{
+			Name: "CustomINITIALISM",
+			Tags: []string{`column:"some_column"`},
+		}
+		column := metadata.Column{Name: "custom_initialism"}
+		resultField := addColumnTag(field, column)
+		require.Contains(t, resultField.Tags, `column:"some_column"`)
+		require.NotContains(t, resultField.Tags, `column:"custom_initialism"`)
+	})
+}
+
 func TestTableModelFieldSourceDialect(t *testing.T) {
 	testCases := []struct {
 		name               string

--- a/generator/template/process.go
+++ b/generator/template/process.go
@@ -319,14 +319,10 @@ func processTableModels(fileTypes, modelDirPath string, tablesMetaData []metadat
 					return tableTemplate
 				},
 				"structField": func(columnMetaData metadata.Column) TableModelField {
-					field := tableTemplate.Field(columnMetaData)
-					if field.Name != DefaultTableModelField(columnMetaData).Name {
-						// If the name has been changed in UseField, we need to add the column tag
-						// to ensure that the right column will be used at runtime.
-						field.Tags = append(field.Tags, fmt.Sprintf("column:%q", columnMetaData.Name))
-					}
-
-					return field
+					return addColumnTag(
+						tableTemplate.Field(columnMetaData),
+						columnMetaData,
+					)
 				},
 				"golangComment": formatGolangComment,
 			})

--- a/generator/template/process.go
+++ b/generator/template/process.go
@@ -319,7 +319,14 @@ func processTableModels(fileTypes, modelDirPath string, tablesMetaData []metadat
 					return tableTemplate
 				},
 				"structField": func(columnMetaData metadata.Column) TableModelField {
-					return tableTemplate.Field(columnMetaData)
+					field := tableTemplate.Field(columnMetaData)
+					if field.Name != DefaultTableModelField(columnMetaData).Name {
+						// If the name has been changed in UseField, we need to add the column tag
+						// to ensure that the right column will be used at runtime.
+						field.Tags = append(field.Tags, fmt.Sprintf("column:%q", columnMetaData.Name))
+					}
+
+					return field
 				},
 				"golangComment": formatGolangComment,
 			})

--- a/internal/jet/utils.go
+++ b/internal/jet/utils.go
@@ -172,14 +172,7 @@ func UnwindRowFromModel(columns []Column, data interface{}) []Serializer {
 	must.ValueBeOfTypeKind(structValue, reflect.Struct, "jet: data has to be a struct")
 
 	for i, column := range columns {
-		columnName := column.Name()
-		structFieldName := dbidentifier.ToGoIdentifier(columnName)
-
-		structField := structValue.FieldByName(structFieldName)
-
-		if !structField.IsValid() {
-			panic("missing struct field for column : " + columnName)
-		}
+		structField := dbidentifier.GetStructFieldForColumn(structValue, column.Name())
 
 		var field interface{}
 

--- a/internal/utils/dbidentifier/dbidentifier.go
+++ b/internal/utils/dbidentifier/dbidentifier.go
@@ -2,6 +2,7 @@ package dbidentifier
 
 import (
 	"github.com/go-jet/jet/v2/internal/3rdparty/snaker"
+	"reflect"
 	"strings"
 	"unicode"
 )
@@ -14,6 +15,28 @@ func ToGoIdentifier(databaseIdentifier string) string {
 // ToGoFileName converts database identifier to Go file name.
 func ToGoFileName(databaseIdentifier string) string {
 	return strings.ToLower(replaceInvalidChars(databaseIdentifier))
+}
+
+// GetStructFieldForColumn retrieves a column value in a struct
+func GetStructFieldForColumn(
+	structValue reflect.Value,
+	columnName string,
+) reflect.Value {
+	// Search the field using the standard name for the column
+	structField := structValue.FieldByName(ToGoIdentifier(columnName))
+	if structField.IsValid() {
+		return structField
+	}
+
+	// In case of a non-standard name, search for a matching column tag
+	for fieldIndex := range structValue.NumField() {
+		columnTag := structValue.Type().Field(fieldIndex).Tag.Get("column")
+		if columnTag == columnName {
+			return structValue.Field(fieldIndex)
+		}
+	}
+
+	panic("missing struct field for column : " + columnName)
 }
 
 func replaceInvalidChars(identifier string) string {

--- a/internal/utils/dbidentifier/dbidentifier_test.go
+++ b/internal/utils/dbidentifier/dbidentifier_test.go
@@ -2,6 +2,7 @@ package dbidentifier
 
 import (
 	"github.com/stretchr/testify/require"
+	"reflect"
 	"testing"
 )
 
@@ -65,4 +66,19 @@ func TestToGoFileName(t *testing.T) {
 	require.Equal(t, ToGoFileName("File\bName"), "filename")
 	require.Equal(t, ToGoFileName("File\tName"), "file_name")
 	require.Equal(t, ToGoFileName("File^^Name"), "file_caret__caret_name")
+}
+
+func TestGetStructFieldForColumn(t *testing.T) {
+	value := reflect.ValueOf(struct {
+		FooID            int
+		Bar              int
+		BazId            int `column:"baz_id"`
+		CustomINITIALISM int `column:"custom_initialism"`
+	}{1, 2, 3, 4})
+
+	require.Equal(t, int64(1), GetStructFieldForColumn(value, "foo_id").Int())
+	require.Equal(t, int64(2), GetStructFieldForColumn(value, "bar").Int())
+	require.Equal(t, int64(3), GetStructFieldForColumn(value, "baz_id").Int())
+	require.Equal(t, int64(4), GetStructFieldForColumn(value, "custom_initialism").Int())
+	require.Panics(t, func() { GetStructFieldForColumn(value, "wrong_property") })
 }

--- a/tests/postgres/generator_template_test.go
+++ b/tests/postgres/generator_template_test.go
@@ -626,7 +626,7 @@ func TestGeneratorTemplate_Model_SqlBuilder_RenameStructFieldNames(t *testing.T)
 	require.NoError(t, err)
 
 	filmModelData := file2.Exists(t, defaultModelPath, "payment.go")
-	require.Contains(t, filmModelData, "AmountInCents decimal.Decimal")
+	require.Contains(t, filmModelData, "AmountInCents decimal.Decimal `column:\"amount\"`")
 	filmSqlBuilderData := file2.Exists(t, defaultSqlBuilderPath, "payment.go")
 	require.Contains(t, filmSqlBuilderData, "AmountInCents postgres.ColumnFloat")
 	require.Contains(t, filmSqlBuilderData, "AmountInCentsColumn = postgres.FloatColumn(\"amount\")")

--- a/tests/postgres/insert_test.go
+++ b/tests/postgres/insert_test.go
@@ -354,6 +354,27 @@ VALUES ('http://www.postgresqltutorial.com', 'PostgreSQL Tutorial'),
 	testutils.AssertExecAndRollback(t, stmt, db, 3)
 }
 
+func TestInsertModelObjectWithCustomFieldName(t *testing.T) {
+	linkData := struct {
+		Url  string `column:"url"`
+		NAME string `column:"name"`
+	}{
+		Url:  "http://www.duckduckgo.com",
+		NAME: "Duck Duck go",
+	}
+
+	query := Link.
+		INSERT(Link.URL, Link.Name).
+		MODEL(linkData)
+
+	testutils.AssertDebugStatementSql(t, query, `
+INSERT INTO test_sample.link (url, name)
+VALUES ('http://www.duckduckgo.com', 'Duck Duck go');
+`, "http://www.duckduckgo.com", "Duck Duck go")
+
+	testutils.AssertExecAndRollback(t, query, db, 1)
+}
+
 func TestInsertUsingMutableColumns(t *testing.T) {
 	google := model.Link{
 		URL:  "http://www.google.com",


### PR DESCRIPTION
This adds a struct tag to manually set the column mapping in case that a non-standard name is used.

The goal of this PR is to fix https://github.com/go-jet/jet/issues/587

Non-standard names can be used with a custom config:
```go
...
.UseField(func(column metadata.Column) template.TableModelField {
	field := template.DefaultTableModelField(column)
	if column.Name == "custom_initialism" {
		field.Name = "CustomINITIALISM"
		field.Tags = append(field.Tags, fmt.Sprintf("column:%q", column.Name))
	}
	return field
})
...
```