### PR TITLE
fix(mysql): support WITH queries in INSERT QUERY

### DIFF
--- a/internal/jet/with_statement.go
+++ b/internal/jet/with_statement.go
@@ -44,9 +44,9 @@ func (w withImpl) serialize(statement StatementType, out *SQLBuilder, options ..
 			out.WriteString(",")
 		}
 
-		cte.serialize(statement, out, FallTrough(options)...)
+		cte.serialize(WithStatementType, out, FallTrough(options)...)
 	}
-	w.primaryStatement.serialize(statement, out, NoWrap.WithFallTrough(options)...)
+	w.primaryStatement.serialize(WithStatementType, out, NoWrap.WithFallTrough(options)...)
 }
 
 func (w withImpl) projections() ProjectionList {

--- a/mysql/insert_statement.go
+++ b/mysql/insert_statement.go
@@ -18,7 +18,7 @@ type InsertStatement interface {
 
 	ON_DUPLICATE_KEY_UPDATE(assigments ...ColumnAssigment) InsertStatement
 
-	QUERY(selectStatement SelectStatement) InsertStatement
+	QUERY(statement Statement) InsertStatement
 
 	RETURNING(projections ...Projection) InsertStatement
 }
@@ -82,8 +82,13 @@ func (is *insertStatementImpl) ON_DUPLICATE_KEY_UPDATE(assigments ...ColumnAssig
 	return is
 }
 
-func (is *insertStatementImpl) QUERY(selectStatement SelectStatement) InsertStatement {
-	is.ValuesQuery.Query = selectStatement
+func (is *insertStatementImpl) QUERY(statement Statement) InsertStatement {
+	query, ok := statement.(jet.SerializerStatement)
+	if !ok {
+		panic("jet: unsupported INSERT query statement")
+	}
+
+	is.ValuesQuery.Query = query
 	return is
 }
 

--- a/mysql/insert_statement_test.go
+++ b/mysql/insert_statement_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,34 @@ VALUES (DEFAULT, ?);
 `
 
 	assertStatementSql(t, stmt, expectedSQL, "two")
+}
+
+func TestInsertQueryWithStatement(t *testing.T) {
+	valuesToInsert := CTE("values_to_insert")
+	valueToInsert := table2ColInt.From(valuesToInsert)
+
+	stmt := table1.INSERT(table1Col1).QUERY(
+		WITH(
+			valuesToInsert.AS(
+				SELECT(table2ColInt).
+					FROM(table2).
+					WHERE(table2ColBool.IS_TRUE()),
+			),
+		)(
+			SELECT(valueToInsert).FROM(valuesToInsert),
+		),
+	)
+
+	assertStatementSql(t, stmt, strings.Replace(`
+INSERT INTO db.table1 (col1)
+WITH values_to_insert AS (
+     SELECT table2.col_int AS "table2.col_int"
+     FROM db.table2
+     WHERE table2.col_bool IS TRUE
+)
+SELECT values_to_insert.''table2.col_int'' AS "table2.col_int"
+FROM values_to_insert;
+`, "''", "`", -1))
 }
 
 func TestInsertOnDuplicateKeyUpdate(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #599.

MySQL `INSERT(...).QUERY(...)` can now accept a `WITH(...)(SELECT(...))` statement as the query source. This also keeps CTE definitions intact when a `WITH` statement is serialized inside an INSERT query.

## Changes

- Allow MySQL insert `QUERY` to accept Jet statements that can be serialized.
- Serialize `WITH` statements with their own statement type when nested.
- Add regression coverage for `INSERT ... QUERY(WITH(...)(SELECT...))`.

## Testing

- `go test ./mysql -run TestInsertQueryWithStatement`
- `go test ./mysql ./postgres ./sqlite`
- `go test ./...`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.