### PR TITLE
Allow a WITH (CTE) statement as an INSERT source query

### DIFF
--- a/internal/jet/with_statement.go
+++ b/internal/jet/with_statement.go
@@ -2,8 +2,10 @@ package jet
 
 import "fmt"
 
-// WITH function creates new with statement from list of common table expressions for specified dialect
-func WITH(dialect Dialect, recursive bool, cte ...*CommonTableExpression) func(statement Statement) Statement {
+// WITH function creates new with statement from list of common table expressions for specified dialect.
+// The returned statement is a SerializerStatement (not just a Statement) so it can be used wherever a serializable
+// statement is expected, for instance as the source of an INSERT ... QUERY(...).
+func WITH(dialect Dialect, recursive bool, cte ...*CommonTableExpression) func(statement Statement) SerializerStatement {
 	newWithImpl := &withImpl{
 		recursive: recursive,
 		ctes:      cte,
@@ -14,7 +16,7 @@ func WITH(dialect Dialect, recursive bool, cte ...*CommonTableExpression) func(s
 	}
 	newWithImpl.root = newWithImpl
 
-	return func(primaryStatement Statement) Statement {
+	return func(primaryStatement Statement) SerializerStatement {
 		serializerStatement, ok := primaryStatement.(SerializerStatement)
 		if !ok {
 			panic("jet: unsupported main WITH statement.")
@@ -44,7 +46,10 @@ func (w withImpl) serialize(statement StatementType, out *SQLBuilder, options ..
 			out.WriteString(",")
 		}
 
-		cte.serialize(statement, out, FallTrough(options)...)
+		// A CTE in a WITH clause is always serialized as a definition (name AS (...)), regardless of the enclosing
+		// statement type. Forwarding the incoming statement type instead would render the CTE in its FROM-clause form
+		// (just the name) whenever the WITH is nested, for example as the source query of an INSERT ... QUERY(WITH(...)).
+		cte.serialize(WithStatementType, out, FallTrough(options)...)
 	}
 	w.primaryStatement.serialize(statement, out, NoWrap.WithFallTrough(options)...)
 }

--- a/mysql/insert_statement.go
+++ b/mysql/insert_statement.go
@@ -18,7 +18,9 @@ type InsertStatement interface {
 
 	ON_DUPLICATE_KEY_UPDATE(assigments ...ColumnAssigment) InsertStatement
 
-	QUERY(selectStatement SelectStatement) InsertStatement
+	// QUERY inserts the rows produced by the provided query. The query is usually a SELECT, but any serializable
+	// statement is accepted, such as a WITH (CTE) statement wrapping a SELECT.
+	QUERY(query jet.SerializerStatement) InsertStatement
 
 	RETURNING(projections ...Projection) InsertStatement
 }
@@ -82,8 +84,8 @@ func (is *insertStatementImpl) ON_DUPLICATE_KEY_UPDATE(assigments ...ColumnAssig
 	return is
 }
 
-func (is *insertStatementImpl) QUERY(selectStatement SelectStatement) InsertStatement {
-	is.ValuesQuery.Query = selectStatement
+func (is *insertStatementImpl) QUERY(query jet.SerializerStatement) InsertStatement {
+	is.ValuesQuery.Query = query
 	return is
 }
 

--- a/mysql/with_statement.go
+++ b/mysql/with_statement.go
@@ -19,12 +19,12 @@ type commonTableExpression struct {
 }
 
 // WITH function creates new WITH statement from list of common table expressions
-func WITH(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, false, toInternalCTE(cte)...)
 }
 
 // WITH_RECURSIVE function creates new WITH RECURSIVE statement from list of common table expressions
-func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, true, toInternalCTE(cte)...)
 }
 

--- a/postgres/insert_statement.go
+++ b/postgres/insert_statement.go
@@ -12,7 +12,9 @@ type InsertStatement interface {
 	// If data is not struct or there is no field for every column selected, this method will panic.
 	MODEL(data interface{}) InsertStatement
 	MODELS(data interface{}) InsertStatement
-	QUERY(selectStatement SelectStatement) InsertStatement
+	// QUERY inserts the rows produced by the provided query. The query is usually a SELECT, but any serializable
+	// statement is accepted, such as a WITH (CTE) statement wrapping a SELECT.
+	QUERY(query jet.SerializerStatement) InsertStatement
 
 	ON_CONFLICT(indexExpressions ...jet.ColumnExpression) onConflict
 
@@ -63,8 +65,8 @@ func (i *insertStatementImpl) RETURNING(projections ...jet.Projection) InsertSta
 	return i
 }
 
-func (i *insertStatementImpl) QUERY(selectStatement SelectStatement) InsertStatement {
-	i.ValuesQuery.Query = selectStatement
+func (i *insertStatementImpl) QUERY(query jet.SerializerStatement) InsertStatement {
+	i.ValuesQuery.Query = query
 	return i
 }
 

--- a/postgres/with_statement.go
+++ b/postgres/with_statement.go
@@ -20,12 +20,12 @@ type commonTableExpression struct {
 }
 
 // WITH function creates new WITH statement from list of common table expressions
-func WITH(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, false, toInternalCTE(cte)...)
 }
 
 // WITH_RECURSIVE function creates new WITH RECURSIVE statement from list of common table expressions
-func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, true, toInternalCTE(cte)...)
 }
 

--- a/sqlite/insert_statement.go
+++ b/sqlite/insert_statement.go
@@ -9,7 +9,9 @@ type InsertStatement interface {
 	VALUES(value interface{}, values ...interface{}) InsertStatement
 	MODEL(data interface{}) InsertStatement
 	MODELS(data interface{}) InsertStatement
-	QUERY(selectStatement SelectStatement) InsertStatement
+	// QUERY inserts the rows produced by the provided query. The query is usually a SELECT, but any serializable
+	// statement is accepted, such as a WITH (CTE) statement wrapping a SELECT.
+	QUERY(query jet.SerializerStatement) InsertStatement
 	DEFAULT_VALUES() InsertStatement
 
 	ON_CONFLICT(indexExpressions ...jet.ColumnExpression) onConflict
@@ -63,8 +65,8 @@ func (is *insertStatementImpl) MODELS(data interface{}) InsertStatement {
 	return is
 }
 
-func (is *insertStatementImpl) QUERY(selectStatement SelectStatement) InsertStatement {
-	is.ValuesQuery.Query = selectStatement
+func (is *insertStatementImpl) QUERY(query jet.SerializerStatement) InsertStatement {
+	is.ValuesQuery.Query = query
 	return is
 }
 

--- a/sqlite/with_statement.go
+++ b/sqlite/with_statement.go
@@ -20,12 +20,12 @@ type commonTableExpression struct {
 }
 
 // WITH function creates new WITH statement from list of common table expressions
-func WITH(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, false, toInternalCTE(cte)...)
 }
 
 // WITH_RECURSIVE function creates new WITH RECURSIVE statement from list of common table expressions
-func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) Statement {
+func WITH_RECURSIVE(cte ...CommonTableExpression) func(statement jet.Statement) jet.SerializerStatement {
 	return jet.WITH(Dialect, true, toInternalCTE(cte)...)
 }
 

--- a/tests/mysql/insert_test.go
+++ b/tests/mysql/insert_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 )
@@ -239,6 +240,46 @@ INSERT INTO test_sample.link (url, name) (
 
 		require.NoError(t, err)
 		require.Equal(t, len(youtubeLinks), 2)
+	})
+}
+
+// TestInsertFromCTEQuery verifies that an INSERT can take a WITH (CTE) statement as its source query.
+// MySQL and MariaDB do not support the `WITH ... INSERT ...` form, so the CTE has to be nested inside the INSERT's
+// QUERY, producing `INSERT INTO t (...) WITH cte AS (...) SELECT ... FROM cte`. See go-jet/jet#599.
+func TestInsertFromCTEQuery(t *testing.T) {
+	newLinks := CTE("new_links")
+
+	stmt := Link.
+		INSERT(Link.URL, Link.Name).
+		QUERY(
+			WITH(
+				newLinks.AS(
+					SELECT(Link.URL, Link.Name).
+						FROM(Link).
+						WHERE(Link.ID.EQ(Int(1))),
+				),
+			)(
+				SELECT(Link.URL.From(newLinks), Link.Name.From(newLinks)).
+					FROM(newLinks),
+			),
+		)
+
+	testutils.AssertDebugStatementSql(t, stmt, strings.Replace(`
+INSERT INTO test_sample.link (url, name)
+WITH new_links AS (
+     SELECT link.url AS "link.url",
+          link.name AS "link.name"
+     FROM test_sample.link
+     WHERE link.id = 1
+)
+SELECT new_links.''link.url'' AS "link.url",
+     new_links.''link.name'' AS "link.name"
+FROM new_links;
+`, "''", "`", -1), int64(1))
+
+	testutils.ExecuteInTxAndRollback(t, db, func(tx qrm.DB) {
+		_, err := stmt.Exec(tx)
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## Why

`INSERT(...).QUERY(...)` only accepted a `SelectStatement`, so a CTE could not be used as the source of an INSERT. As reported in #599, MySQL and MariaDB do not support the `WITH ... INSERT ...` form, so the CTE has to be nested inside the INSERT:

```sql
INSERT INTO insertion_table (col_1, col_2)
WITH cte_name AS (
    SELECT ...
)
SELECT ... FROM cte_name
```

There was no way to express this, because `QUERY` rejected the `WITH(...)(SELECT ...)` value at compile time.

## What

- Widen `QUERY` to accept `jet.SerializerStatement` (mysql, postgres, sqlite). This is the type the underlying `ValuesQuery.Query` field already holds, and a `SELECT` still satisfies it, so existing `QUERY(SELECT(...))` calls are unaffected.
- Widen the `WITH` / `WITH_RECURSIVE` constructor return type from `Statement` to `SerializerStatement` so the result can be passed to `QUERY`. `SerializerStatement` embeds `Statement`, so this is a backward-compatible widening for existing callers.
- Fix `WITH` serialization: a CTE in a `WITH` clause must always serialize as a definition (`name AS (...)`). It previously forwarded the enclosing statement type down to the CTE, which rendered only the CTE name (its FROM-clause form) when the `WITH` was nested inside another statement, dropping the `AS (...)` body.

This follows the direction you suggested on the issue (replacing `SelectStatement` with `jet.SerializerStatement`); the `WITH` return-type widening and the serialization fix are what make that actually compile and emit correct SQL.

## Resulting SQL

```go
Link.INSERT(Link.URL, Link.Name).
    QUERY(
        WITH(
            newLinks.AS(
                SELECT(Link.URL, Link.Name).FROM(Link).WHERE(Link.ID.EQ(Int(1))),
            ),
        )(
            SELECT(Link.URL.From(newLinks), Link.Name.From(newLinks)).FROM(newLinks),
        ),
    )
```

```sql
INSERT INTO test_sample.link (url, name)
WITH new_links AS (
     SELECT link.url AS "link.url",
          link.name AS "link.name"
     FROM test_sample.link
     WHERE link.id = 1
)
SELECT new_links.`link.url` AS "link.url",
     new_links.`link.name` AS "link.name"
FROM new_links;
```

## Testing

- Added `TestInsertFromCTEQuery` in `tests/mysql/insert_test.go` (SQL assertion + executes against the DB).
- Verified the generated SQL locally and confirmed existing top-level `WITH ... SELECT/UPDATE/DELETE` output is unchanged; `go build ./...`, `go vet`, and `go test ./internal/...` pass. I don't have a local MySQL/MariaDB, so the `tests/...` integration suite runs in CI.

Fixes #599
