### PR TITLE
feat: export setStatement

### DIFF
--- a/mysql/select_statement.go
+++ b/mysql/select_statement.go
@@ -54,8 +54,8 @@ type SelectStatement interface {
 	FOR(lock RowLock) SelectStatement
 	LOCK_IN_SHARE_MODE() SelectStatement
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
 
 	AsTable(alias string) SelectTable
 }

--- a/mysql/set_statement.go
+++ b/mysql/set_statement.go
@@ -4,23 +4,23 @@ import "github.com/go-jet/jet/v2/internal/jet"
 
 // UNION effectively appends the result of sub-queries(select statements) into single query.
 // It eliminates duplicate rows from its result.
-func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, false, toSelectList(lhs, rhs, selects...))
 }
 
 // UNION_ALL effectively appends the result of sub-queries(select statements) into single query.
 // It does not eliminates duplicate rows from its result.
-func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, true, toSelectList(lhs, rhs, selects...))
 }
 
-type setStatement interface {
+type SetStatement interface {
 	setOperators
 
-	ORDER_BY(orderByClauses ...OrderByClause) setStatement
+	ORDER_BY(orderByClauses ...OrderByClause) SetStatement
 
-	LIMIT(limit int64) setStatement
-	OFFSET(offset int64) setStatement
+	LIMIT(limit int64) SetStatement
+	OFFSET(offset int64) SetStatement
 
 	AsTable(alias string) SelectTable
 }
@@ -30,19 +30,19 @@ type setOperators interface {
 	jet.HasProjections
 	jet.Expression
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
 }
 
 type setOperatorsImpl struct {
 	root setOperators
 }
 
-func (s *setOperatorsImpl) UNION(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION(rhs SelectStatement) SetStatement {
 	return UNION(s.root, rhs)
 }
 
-func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) SetStatement {
 	return UNION_ALL(s.root, rhs)
 }
 
@@ -54,7 +54,7 @@ type setStatementImpl struct {
 	setOperator jet.ClauseSetStmtOperator
 }
 
-func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) setStatement {
+func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) SetStatement {
 	newSetStatement := &setStatementImpl{}
 	newSetStatement.ExpressionStatement = jet.NewExpressionStatementImpl(Dialect, jet.SetStatementType, newSetStatement,
 		&newSetStatement.setOperator)
@@ -69,17 +69,17 @@ func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStat
 	return newSetStatement
 }
 
-func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) setStatement {
+func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) SetStatement {
 	s.setOperator.OrderBy.List = orderByClauses
 	return s
 }
 
-func (s *setStatementImpl) LIMIT(limit int64) setStatement {
+func (s *setStatementImpl) LIMIT(limit int64) SetStatement {
 	s.setOperator.Limit.Count = limit
 	return s
 }
 
-func (s *setStatementImpl) OFFSET(offset int64) setStatement {
+func (s *setStatementImpl) OFFSET(offset int64) SetStatement {
 	s.setOperator.Offset.Count = Int(offset)
 	return s
 }

--- a/postgres/select_statement.go
+++ b/postgres/select_statement.go
@@ -58,12 +58,12 @@ type SelectStatement interface {
 	FETCH_FIRST(count IntegerExpression) fetchExpand
 	FOR(lock RowLock) SelectStatement
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
-	INTERSECT(rhs SelectStatement) setStatement
-	INTERSECT_ALL(rhs SelectStatement) setStatement
-	EXCEPT(rhs SelectStatement) setStatement
-	EXCEPT_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
+	INTERSECT(rhs SelectStatement) SetStatement
+	INTERSECT_ALL(rhs SelectStatement) SetStatement
+	EXCEPT(rhs SelectStatement) SetStatement
+	EXCEPT_ALL(rhs SelectStatement) SetStatement
 
 	AsTable(alias string) SelectTable
 }

--- a/postgres/set_statement.go
+++ b/postgres/set_statement.go
@@ -4,49 +4,49 @@ import "github.com/go-jet/jet/v2/internal/jet"
 
 // UNION effectively appends the result of sub-queries(select statements) into single query.
 // It eliminates duplicate rows from its result.
-func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, false, toSelectList(lhs, rhs, selects...))
 }
 
 // UNION_ALL effectively appends the result of sub-queries(select statements) into single query.
 // It does not eliminates duplicate rows from its result.
-func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, true, toSelectList(lhs, rhs, selects...))
 }
 
 // INTERSECT returns all rows that are in query results.
 // It eliminates duplicate rows from its result.
-func INTERSECT(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func INTERSECT(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(intersect, false, toSelectList(lhs, rhs, selects...))
 }
 
 // INTERSECT_ALL returns all rows that are in query results.
 // It does not eliminates duplicate rows from its result.
-func INTERSECT_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func INTERSECT_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(intersect, true, toSelectList(lhs, rhs, selects...))
 }
 
 // EXCEPT returns all rows that are in the result of query lhs but not in the result of query rhs.
 // It eliminates duplicate rows from its result.
-func EXCEPT(lhs, rhs jet.SerializerStatement) setStatement {
+func EXCEPT(lhs, rhs jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(except, false, toSelectList(lhs, rhs))
 }
 
 // EXCEPT_ALL returns all rows that are in the result of query lhs but not in the result of query rhs.
 // It does not eliminates duplicate rows from its result.
-func EXCEPT_ALL(lhs, rhs jet.SerializerStatement) setStatement {
+func EXCEPT_ALL(lhs, rhs jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(except, true, toSelectList(lhs, rhs))
 }
 
-type setStatement interface {
+type SetStatement interface {
 	setOperators
 
-	ORDER_BY(orderByClauses ...OrderByClause) setStatement
+	ORDER_BY(orderByClauses ...OrderByClause) SetStatement
 
-	LIMIT(limit int64) setStatement
-	OFFSET(offset int64) setStatement
+	LIMIT(limit int64) SetStatement
+	OFFSET(offset int64) SetStatement
 	// OFFSET_e can be used when an integer expression is needed as offset, otherwise OFFSET can be used
-	OFFSET_e(offset IntegerExpression) setStatement
+	OFFSET_e(offset IntegerExpression) SetStatement
 
 	AsTable(alias string) SelectTable
 }
@@ -56,39 +56,39 @@ type setOperators interface {
 	jet.HasProjections
 	Expression
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
-	INTERSECT(rhs SelectStatement) setStatement
-	INTERSECT_ALL(rhs SelectStatement) setStatement
-	EXCEPT(rhs SelectStatement) setStatement
-	EXCEPT_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
+	INTERSECT(rhs SelectStatement) SetStatement
+	INTERSECT_ALL(rhs SelectStatement) SetStatement
+	EXCEPT(rhs SelectStatement) SetStatement
+	EXCEPT_ALL(rhs SelectStatement) SetStatement
 }
 
 type setOperatorsImpl struct {
 	stmtRoot setOperators
 }
 
-func (s *setOperatorsImpl) UNION(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION(rhs SelectStatement) SetStatement {
 	return UNION(s.stmtRoot, rhs)
 }
 
-func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) SetStatement {
 	return UNION_ALL(s.stmtRoot, rhs)
 }
 
-func (s *setOperatorsImpl) INTERSECT(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) INTERSECT(rhs SelectStatement) SetStatement {
 	return INTERSECT(s.stmtRoot, rhs)
 }
 
-func (s *setOperatorsImpl) INTERSECT_ALL(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) INTERSECT_ALL(rhs SelectStatement) SetStatement {
 	return INTERSECT_ALL(s.stmtRoot, rhs)
 }
 
-func (s *setOperatorsImpl) EXCEPT(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) EXCEPT(rhs SelectStatement) SetStatement {
 	return EXCEPT(s.stmtRoot, rhs)
 }
 
-func (s *setOperatorsImpl) EXCEPT_ALL(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) EXCEPT_ALL(rhs SelectStatement) SetStatement {
 	return EXCEPT_ALL(s.stmtRoot, rhs)
 }
 
@@ -100,7 +100,7 @@ type setStatementImpl struct {
 	setOperator jet.ClauseSetStmtOperator
 }
 
-func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) setStatement {
+func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) SetStatement {
 	newSetStatement := &setStatementImpl{}
 	newSetStatement.ExpressionStatement = jet.NewExpressionStatementImpl(Dialect, jet.SetStatementType, newSetStatement,
 		&newSetStatement.setOperator)
@@ -115,22 +115,22 @@ func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStat
 	return newSetStatement
 }
 
-func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) setStatement {
+func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) SetStatement {
 	s.setOperator.OrderBy.List = orderByClauses
 	return s
 }
 
-func (s *setStatementImpl) LIMIT(limit int64) setStatement {
+func (s *setStatementImpl) LIMIT(limit int64) SetStatement {
 	s.setOperator.Limit.Count = limit
 	return s
 }
 
-func (s *setStatementImpl) OFFSET(offset int64) setStatement {
+func (s *setStatementImpl) OFFSET(offset int64) SetStatement {
 	s.setOperator.Offset.Count = Int(offset)
 	return s
 }
 
-func (s *setStatementImpl) OFFSET_e(offset IntegerExpression) setStatement {
+func (s *setStatementImpl) OFFSET_e(offset IntegerExpression) SetStatement {
 	s.setOperator.Offset.Count = offset
 	return s
 }

--- a/sqlite/select_statement.go
+++ b/sqlite/select_statement.go
@@ -52,8 +52,8 @@ type SelectStatement interface {
 	FOR(lock RowLock) SelectStatement
 	LOCK_IN_SHARE_MODE() SelectStatement
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
 
 	AsTable(alias string) SelectTable
 }

--- a/sqlite/set_statement.go
+++ b/sqlite/set_statement.go
@@ -4,23 +4,23 @@ import "github.com/go-jet/jet/v2/internal/jet"
 
 // UNION effectively appends the result of sub-queries(select statements) into single query.
 // It eliminates duplicate rows from its result.
-func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, false, toSelectList(lhs, rhs, selects...))
 }
 
 // UNION_ALL effectively appends the result of sub-queries(select statements) into single query.
 // It does not eliminates duplicate rows from its result.
-func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) setStatement {
+func UNION_ALL(lhs, rhs jet.SerializerStatement, selects ...jet.SerializerStatement) SetStatement {
 	return newSetStatementImpl(union, true, toSelectList(lhs, rhs, selects...))
 }
 
-type setStatement interface {
+type SetStatement interface {
 	setOperators
 
-	ORDER_BY(orderByClauses ...OrderByClause) setStatement
+	ORDER_BY(orderByClauses ...OrderByClause) SetStatement
 
-	LIMIT(limit int64) setStatement
-	OFFSET(offset int64) setStatement
+	LIMIT(limit int64) SetStatement
+	OFFSET(offset int64) SetStatement
 
 	AsTable(alias string) SelectTable
 }
@@ -30,19 +30,19 @@ type setOperators interface {
 	jet.HasProjections
 	jet.Expression
 
-	UNION(rhs SelectStatement) setStatement
-	UNION_ALL(rhs SelectStatement) setStatement
+	UNION(rhs SelectStatement) SetStatement
+	UNION_ALL(rhs SelectStatement) SetStatement
 }
 
 type setOperatorsImpl struct {
 	root setOperators
 }
 
-func (s *setOperatorsImpl) UNION(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION(rhs SelectStatement) SetStatement {
 	return UNION(s.root, rhs)
 }
 
-func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) setStatement {
+func (s *setOperatorsImpl) UNION_ALL(rhs SelectStatement) SetStatement {
 	return UNION_ALL(s.root, rhs)
 }
 
@@ -54,7 +54,7 @@ type setStatementImpl struct {
 	setOperator jet.ClauseSetStmtOperator
 }
 
-func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) setStatement {
+func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStatement) SetStatement {
 	newSetStatement := &setStatementImpl{}
 	newSetStatement.ExpressionStatement = jet.NewExpressionStatementImpl(Dialect, jet.SetStatementType, newSetStatement,
 		&newSetStatement.setOperator)
@@ -70,17 +70,17 @@ func newSetStatementImpl(operator string, all bool, selects []jet.SerializerStat
 	return newSetStatement
 }
 
-func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) setStatement {
+func (s *setStatementImpl) ORDER_BY(orderByClauses ...OrderByClause) SetStatement {
 	s.setOperator.OrderBy.List = orderByClauses
 	return s
 }
 
-func (s *setStatementImpl) LIMIT(limit int64) setStatement {
+func (s *setStatementImpl) LIMIT(limit int64) SetStatement {
 	s.setOperator.Limit.Count = limit
 	return s
 }
 
-func (s *setStatementImpl) OFFSET(offset int64) setStatement {
+func (s *setStatementImpl) OFFSET(offset int64) SetStatement {
 	s.setOperator.Offset.Count = Int(offset)
 	return s
 }


### PR DESCRIPTION
I came across https://github.com/go-jet/jet/issues/485 as well and thought I'll gladly go and export the interface. :smile:

This PR exports the `setStatement` -> `SetStatement` interface for each db's package.