### PR TITLE
Move test utilities out of runtime packages

### DIFF
--- a/internal/jet/testutils_test.go
+++ b/internal/jet/testutils_test.go
@@ -1,21 +1,10 @@
 package jet
 
 import (
-	"github.com/stretchr/testify/require"
-	"strconv"
 	"testing"
-)
 
-var defaultDialect = NewDialect(DialectParams{ // just for tests
-	AliasQuoteChar:      '"',
-	IdentifierQuoteChar: '"',
-	ArgumentPlaceholder: func(ord int) string {
-		return "$" + strconv.Itoa(ord)
-	},
-	ArgumentToString: func(value any) (string, bool) {
-		return "", false
-	},
-})
+	"github.com/stretchr/testify/require"
+)
 
 var (
 	table1Col1           = IntegerColumn("col1")

--- a/internal/jet/utils.go
+++ b/internal/jet/utils.go
@@ -2,11 +2,23 @@ package jet
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/go-jet/jet/v2/internal/utils/dbidentifier"
 	"github.com/go-jet/jet/v2/internal/utils/must"
 )
+
+var defaultDialect = NewDialect(DialectParams{
+	AliasQuoteChar:      '"',
+	IdentifierQuoteChar: '"',
+	ArgumentPlaceholder: func(ord int) string {
+		return "$" + strconv.Itoa(ord)
+	},
+	ArgumentToString: func(value any) (string, bool) {
+		return "", false
+	},
+})
 
 // SerializeClauseList func
 func SerializeClauseList(statement StatementType, clauses []Serializer, out *SQLBuilder) {


### PR DESCRIPTION
## Summary

- Rename internal/jet/testutils.go to internal/jet/testutils_test.go.
- Keep the default dialect used by production debug serialization in utils.go.
- Remove testing, Testify, and its dependencies from the runtime package closure.

## Why

The test utility file was compiled as production code because its name did not end in _test.go. Since it imports testing and Testify, every consumer of the SQL builder also linked Testify and gopkg.in/yaml.v3.

Before this change, go list -deps ./mysql included Testify and gopkg.in/yaml.v3. After this change, neither is present.

## Validation

- go test ./...
- golangci-lint run --timeout=30m ./...
- go list -deps ./mysql dependency check