### PR TITLE
Support variadic `FOR UPDATE` + `FOR SHARE` locking for MySQL and Postgres

### DIFF
--- a/internal/jet/clause.go
+++ b/internal/jet/clause.go
@@ -281,18 +281,20 @@ func (o *ClauseFetch) Serialize(statementType StatementType, out *SQLBuilder, op
 
 // ClauseFor struct
 type ClauseFor struct {
-	Lock RowLock
+	Locks []RowLock
 }
 
 // Serialize serializes clause into SQLBuilder
 func (f *ClauseFor) Serialize(statementType StatementType, out *SQLBuilder, options ...SerializeOption) {
-	if f.Lock == nil {
-		return
-	}
+	for _, lock := range f.Locks {
+		if lock == nil {
+			continue
+		}
 
-	out.NewLine()
-	out.WriteString("FOR")
-	f.Lock.serialize(statementType, out, FallTrough(options)...)
+		out.NewLine()
+		out.WriteString("FOR")
+		lock.serialize(statementType, out, FallTrough(options)...)
+	}
 }
 
 // ClauseSetStmtOperator struct

--- a/mysql/select_statement.go
+++ b/mysql/select_statement.go
@@ -51,7 +51,7 @@ type SelectStatement interface {
 	ORDER_BY(orderByClauses ...OrderByClause) SelectStatement
 	LIMIT(limit int64) SelectStatement
 	OFFSET(offset int64) SelectStatement
-	FOR(lock RowLock) SelectStatement
+	FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement
 	LOCK_IN_SHARE_MODE() SelectStatement
 
 	UNION(rhs SelectStatement) SetStatement
@@ -161,8 +161,8 @@ func (s *selectStatementImpl) OFFSET(offset int64) SelectStatement {
 	return s
 }
 
-func (s *selectStatementImpl) FOR(lock RowLock) SelectStatement {
-	s.For.Lock = lock
+func (s *selectStatementImpl) FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement {
+	s.For.Locks = append([]RowLock{lock}, additionalLocks...)
 	return s
 }
 

--- a/mysql/select_statement_test.go
+++ b/mysql/select_statement_test.go
@@ -128,6 +128,26 @@ SELECT table1.col_bool AS "table1.col_bool"
 FROM db.table1
 FOR UPDATE OF table1 NOWAIT;
 `)
+	testutils.AssertStatementSql(t, SELECT(table1ColBool).FROM(table1.INNER_JOIN(table2, table1ColInt.EQ(table2ColInt))).
+		FOR(UPDATE().OF(table1), SHARE().OF(table2)), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+     INNER JOIN db.table2 ON (table1.col_int = table2.col_int)
+FOR UPDATE OF table1
+FOR SHARE OF table2;
+`)
+	testutils.AssertStatementSql(t, SELECT(table1ColBool).FROM(table1).FOR(UPDATE().OF(table1).NOWAIT(), SHARE().OF(table2).SKIP_LOCKED()), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+FOR UPDATE OF table1 NOWAIT
+FOR SHARE OF table2 SKIP LOCKED;
+`)
+	testutils.AssertStatementSql(t, SELECT(table1ColBool).FROM(table1).FOR(SHARE().OF(table1, table2), UPDATE().OF(table3)), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+FOR SHARE OF table1, table2
+FOR UPDATE OF table3;
+`)
 }
 
 func TestSelect_LOCK_IN_SHARE_MODE(t *testing.T) {

--- a/postgres/select_json.go
+++ b/postgres/select_json.go
@@ -92,8 +92,8 @@ func (s *selectJsonStatement) FETCH_FIRST(count IntegerExpression) fetchExpand {
 	}
 }
 
-func (s *selectJsonStatement) FOR(lock RowLock) SelectStatement {
-	s.subQuery.For.Lock = lock
+func (s *selectJsonStatement) FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement {
+	s.subQuery.For.Locks = append([]RowLock{lock}, additionalLocks...)
 	return s
 }
 

--- a/postgres/select_statement.go
+++ b/postgres/select_statement.go
@@ -56,7 +56,7 @@ type SelectStatement interface {
 	// OFFSET_e can be used when an integer expression is needed as offset, otherwise OFFSET can be used
 	OFFSET_e(offset IntegerExpression) SelectStatement
 	FETCH_FIRST(count IntegerExpression) fetchExpand
-	FOR(lock RowLock) SelectStatement
+	FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement
 
 	UNION(rhs SelectStatement) SetStatement
 	UNION_ALL(rhs SelectStatement) SetStatement
@@ -179,8 +179,8 @@ func (s *selectStatementImpl) FETCH_FIRST(count IntegerExpression) fetchExpand {
 	}
 }
 
-func (s *selectStatementImpl) FOR(lock RowLock) SelectStatement {
-	s.For.Lock = lock
+func (s *selectStatementImpl) FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement {
+	s.For.Locks = append([]RowLock{lock}, additionalLocks...)
 	return s
 }
 

--- a/postgres/select_statement_test.go
+++ b/postgres/select_statement_test.go
@@ -139,4 +139,10 @@ SELECT table1.col_bool AS "table1.col_bool"
 FROM db.table1
 FOR UPDATE OF table1, table2 NOWAIT;
 `)
+	assertStatementSql(t, SELECT(table1ColBool).FROM(table1).FOR(UPDATE().OF(table1).NOWAIT(), KEY_SHARE().OF(table2)), `
+SELECT table1.col_bool AS "table1.col_bool"
+FROM db.table1
+FOR UPDATE OF table1 NOWAIT
+FOR KEY SHARE OF table2;
+`)
 }

--- a/sqlite/select_statement.go
+++ b/sqlite/select_statement.go
@@ -49,7 +49,7 @@ type SelectStatement interface {
 	ORDER_BY(orderByClauses ...OrderByClause) SelectStatement
 	LIMIT(limit int64) SelectStatement
 	OFFSET(offset int64) SelectStatement
-	FOR(lock RowLock) SelectStatement
+	FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement
 	LOCK_IN_SHARE_MODE() SelectStatement
 
 	UNION(rhs SelectStatement) SetStatement
@@ -144,8 +144,8 @@ func (s *selectStatementImpl) OFFSET(offset int64) SelectStatement {
 	return s
 }
 
-func (s *selectStatementImpl) FOR(lock RowLock) SelectStatement {
-	s.For.Lock = lock
+func (s *selectStatementImpl) FOR(lock RowLock, additionalLocks ...RowLock) SelectStatement {
+	s.For.Locks = append([]RowLock{lock}, additionalLocks...)
 	return s
 }
 

--- a/tests/mysql/select_test.go
+++ b/tests/mysql/select_test.go
@@ -1036,6 +1036,103 @@ FOR UPDATE OF ''myFilm'';
 	})
 }
 
+func TestRowLockMultipleLockClauses(t *testing.T) {
+	skipForMariaDB(t) // MariaDB does not support UPDATE OF
+
+	myFilm := Film.AS("myFilm")
+	myActor := Actor.AS("myActor")
+
+	stmt := SELECT(
+		myFilm.FilmID,
+		myFilm.Title,
+		myActor.ActorID,
+		myActor.FirstName,
+	).FROM(
+		myFilm.
+			INNER_JOIN(FilmActor, FilmActor.FilmID.EQ(myFilm.FilmID)).
+			INNER_JOIN(myActor, myActor.ActorID.EQ(FilmActor.ActorID)),
+	).LIMIT(
+		1,
+	).FOR(
+		UPDATE().OF(myFilm).NOWAIT(),
+		SHARE().OF(myActor).SKIP_LOCKED(),
+	)
+
+	testutils.AssertDebugStatementSql(t, stmt, strings.ReplaceAll(`
+SELECT ''myFilm''.film_id AS "myFilm.film_id",
+     ''myFilm''.title AS "myFilm.title",
+     ''myActor''.actor_id AS "myActor.actor_id",
+     ''myActor''.first_name AS "myActor.first_name"
+FROM dvds.film AS ''myFilm''
+     INNER JOIN dvds.film_actor ON (film_actor.film_id = ''myFilm''.film_id)
+     INNER JOIN dvds.actor AS ''myActor'' ON (''myActor''.actor_id = film_actor.actor_id)
+LIMIT 1
+FOR UPDATE OF ''myFilm'' NOWAIT
+FOR SHARE OF ''myActor'' SKIP LOCKED;
+`, "''", "`"))
+
+	testutils.ExecuteInTxAndRollback(t, db, func(tx qrm.DB) {
+		var dest []struct {
+			model.Film  `alias:"myFilm.*"`
+			model.Actor `alias:"myActor.*"`
+		}
+
+		err := stmt.Query(tx, &dest)
+		require.NoError(t, err)
+		require.Len(t, dest, 1)
+	})
+}
+
+func TestRowLockMultipleLockClausesMultipleTables(t *testing.T) {
+	skipForMariaDB(t) // MariaDB does not support UPDATE OF
+
+	myActor := Actor.AS("myActor")
+
+	stmt := SELECT(
+		Film.FilmID,
+		FilmActor.ActorID,
+		myActor.FirstName,
+		FilmCategory.CategoryID,
+	).FROM(
+		Film.
+			INNER_JOIN(FilmActor, FilmActor.FilmID.EQ(Film.FilmID)).
+			INNER_JOIN(myActor, myActor.ActorID.EQ(FilmActor.ActorID)).
+			INNER_JOIN(FilmCategory, FilmCategory.FilmID.EQ(Film.FilmID)),
+	).LIMIT(
+		1,
+	).FOR(
+		SHARE().OF(Film, FilmActor),
+		UPDATE().OF(myActor).NOWAIT(),
+	)
+
+	testutils.AssertDebugStatementSql(t, stmt, strings.ReplaceAll(`
+SELECT film.film_id AS "film.film_id",
+     film_actor.actor_id AS "film_actor.actor_id",
+     ''myActor''.first_name AS "myActor.first_name",
+     film_category.category_id AS "film_category.category_id"
+FROM dvds.film
+     INNER JOIN dvds.film_actor ON (film_actor.film_id = film.film_id)
+     INNER JOIN dvds.actor AS ''myActor'' ON (''myActor''.actor_id = film_actor.actor_id)
+     INNER JOIN dvds.film_category ON (film_category.film_id = film.film_id)
+LIMIT 1
+FOR SHARE OF film, film_actor
+FOR UPDATE OF ''myActor'' NOWAIT;
+`, "''", "`"))
+
+	testutils.ExecuteInTxAndRollback(t, db, func(tx qrm.DB) {
+		var dest []struct {
+			model.Film
+			model.FilmActor
+			model.Actor `alias:"myActor.*"`
+			model.FilmCategory
+		}
+
+		err := stmt.Query(tx, &dest)
+		require.NoError(t, err)
+		require.Len(t, dest, 1)
+	})
+}
+
 func TestExpressionWrappers(t *testing.T) {
 	query := SELECT(
 		BoolExp(Raw("true")),

--- a/tests/postgres/select_test.go
+++ b/tests/postgres/select_test.go
@@ -2710,6 +2710,57 @@ FOR UPDATE OF "myFilm";
 	})
 }
 
+func TestSelectRowLockMultipleLockClauses(t *testing.T) {
+
+	myActor := Actor.AS("myActor")
+
+	stmt := SELECT(
+		Film.FilmID,
+		FilmActor.ActorID,
+		myActor.FirstName,
+		FilmCategory.CategoryID,
+	).FROM(
+		Film.
+			INNER_JOIN(FilmActor, FilmActor.FilmID.EQ(Film.FilmID)).
+			INNER_JOIN(myActor, myActor.ActorID.EQ(FilmActor.ActorID)).
+			INNER_JOIN(FilmCategory, FilmCategory.FilmID.EQ(Film.FilmID)),
+	).LIMIT(
+		1,
+	).FOR(
+		SHARE().OF(Film, FilmActor),
+		UPDATE().OF(myActor).NOWAIT(),
+		KEY_SHARE().OF(FilmCategory).SKIP_LOCKED(),
+	)
+
+	testutils.AssertDebugStatementSql(t, stmt, `
+SELECT film.film_id AS "film.film_id",
+     film_actor.actor_id AS "film_actor.actor_id",
+     "myActor".first_name AS "myActor.first_name",
+     film_category.category_id AS "film_category.category_id"
+FROM dvds.film
+     INNER JOIN dvds.film_actor ON (film_actor.film_id = film.film_id)
+     INNER JOIN dvds.actor AS "myActor" ON ("myActor".actor_id = film_actor.actor_id)
+     INNER JOIN dvds.film_category ON (film_category.film_id = film.film_id)
+LIMIT 1
+FOR SHARE OF film, film_actor
+FOR UPDATE OF "myActor" NOWAIT
+FOR KEY SHARE OF film_category SKIP LOCKED;
+`)
+
+	testutils.ExecuteInTxAndRollback(t, db, func(tx qrm.DB) {
+		var dest []struct {
+			model.Film
+			model.FilmActor
+			model.Actor `alias:"myActor.*"`
+			model.FilmCategory
+		}
+
+		err := stmt.Query(tx, &dest)
+		require.NoError(t, err)
+		require.Len(t, dest, 1)
+	})
+}
+
 func TestSelectQuickStart(t *testing.T) {
 
 	stmt := SELECT(


### PR DESCRIPTION
In MySQL and Postgres (not MariaDB), you can do:

 ```sql                                                                                                                                                                                                                                                                                                                               
SELECT * FROM foo f
INNER JOIN bar b ON b.foo_id = f.id
INNER JOIN baz z ON z.foo_id = f.id
FOR SHARE OF f, b
FOR UPDATE OF z
```

This S-locks `f` and `b`, X-locks `z`, and leaves any other joined table unlocked.                                                                                                                                                                                                                                                   Jet's `ClauseFor` held a single `RowLock`, so only one `FOR ...` clause was possible.
This PR makes `FOR` variadic, i.e.

```go                                                                                                                                                                                                                                                                                                                                
SELECT(...).
FROM(f.INNER_JOIN(b, ...).INNER_JOIN(z, ...)).
FOR(
  SHARE().OF(f, b),
   UPDATE().OF(z).NOWAIT(),                                                                                                                                                                                                                                                                                                     
)                                                                                                                                                                                                                                                                                                                                
```

On a side note: SQLite does *not* support the `FOR` or `LOCK IN SHARE MODE` keywords at all. This will always result in a syntax error and should be removed from the SQLite package entirely. For parity, I added the same change to the SQLite API in this PR, but it's effectively dead code. I would do that in a separate PR after merging this one, though.