### PR TITLE
Add ORDER BY support for aggregate functions

### DIFF
--- a/internal/jet/aggregate_functions.go
+++ b/internal/jet/aggregate_functions.go
@@ -1,0 +1,62 @@
+package jet
+
+// AggregateFunc is a named aggregate function (e.g. json_agg) with an optional
+// embedded ORDER BY clause. The ORDER BY is serialized inside the function call:
+//
+//	json_agg(expr ORDER BY col)
+//
+// which is the PostgreSQL syntax for ordering the input rows of an aggregate.
+type AggregateFunc struct {
+	Expression
+
+	name     string
+	argument Expression
+	orderBy  []OrderByClause
+}
+
+// ORDER_BY sets the ORDER BY clause of the aggregate input rows.
+func (a *AggregateFunc) ORDER_BY(orderBy ...OrderByClause) Expression {
+	a.orderBy = orderBy
+	return a.Expression
+}
+
+// NewAggregateFunc creates a named aggregate function expression. The returned
+// Expression carries an optional embedded ORDER BY clause settable via ORDER_BY:
+//
+//	json_agg(expr ORDER BY col)
+func NewAggregateFunc(name string, argument Expression) *AggregateFunc {
+	aggFunc := &AggregateFunc{
+		name:     name,
+		argument: argument,
+	}
+	aggFunc.Expression = newExpression(newAggregateFuncSerializer(aggFunc))
+	return aggFunc
+}
+
+func newAggregateFuncSerializer(aggFunc *AggregateFunc) *aggregateFuncSerializer {
+	return &aggregateFuncSerializer{AggregateFunc: aggFunc}
+}
+
+type aggregateFuncSerializer struct {
+	*AggregateFunc
+}
+
+func (a *aggregateFuncSerializer) serialize(statement StatementType, out *SQLBuilder, options ...SerializeOption) {
+	out.WriteString(a.name + "(")
+
+	if a.argument != nil {
+		wrap(a.argument).serialize(statement, out, FallTrough(options)...)
+	}
+
+	if len(a.orderBy) > 0 {
+		out.WriteString(" ORDER BY ")
+		for i, orderBy := range a.orderBy {
+			if i > 0 {
+				out.WriteString(", ")
+			}
+			orderBy.serializeForOrderBy(statement, out)
+		}
+	}
+
+	out.WriteString(")")
+}

--- a/postgres/aggregate_functions.go
+++ b/postgres/aggregate_functions.go
@@ -1,0 +1,18 @@
+package postgres
+
+import "github.com/go-jet/jet/v2/internal/jet"
+
+// JSON_AGG returns a json_agg aggregate expression. Aggregate input rows can be
+// ordered with ORDER_BY, e.g.:
+//
+//	JSON_AGG(expr).ORDER_BY(Column.ASC())
+//
+// which serializes to json_agg(expr ORDER BY column ASC).
+func JSON_AGG(expression Expression) *jet.AggregateFunc {
+	return jet.NewAggregateFunc("json_agg", expression)
+}
+
+// ARRAY_AGG returns an array_agg aggregate expression with optional ORDER BY.
+func ARRAY_AGG(expression Expression) *jet.AggregateFunc {
+	return jet.NewAggregateFunc("array_agg", expression)
+}

--- a/postgres/aggregate_functions_test.go
+++ b/postgres/aggregate_functions_test.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/go-jet/jet/v2/internal/testutils"
+)
+
+func TestAggregateFunc_JSON_AGG_OrderBy(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+
+	agg := JSON_AGG(
+		Func("json_build_object", String("'salary'"), salary, String("'name'"), name),
+	).ORDER_BY(salary.ASC())
+
+	stmt := SELECT(
+		IntegerColumn("company_id"),
+		agg.AS("employees"),
+	).FROM(NewTable("public", "employee", "e", salary, name))
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT company_id AS "company_id",
+     json_agg((json_build_object($1::text, e.salary, $2::text, e.name)) ORDER BY e.salary ASC) AS "employees"
+FROM public.employee AS e;
+`, "'salary'", "'name'")
+}
+
+func TestAggregateFunc_JSON_AGG_OrderByDescNullsLast(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+
+	agg := JSON_AGG(
+		Func("json_build_object", String("'salary'"), salary, String("'name'"), name),
+	).ORDER_BY(salary.DESC().NULLS_LAST())
+
+	stmt := SELECT(
+		IntegerColumn("company_id"),
+		agg.AS("employees"),
+	).FROM(NewTable("public", "employee", "e", salary, name))
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT company_id AS "company_id",
+     json_agg((json_build_object($1::text, e.salary, $2::text, e.name)) ORDER BY e.salary DESC NULLS LAST) AS "employees"
+FROM public.employee AS e;
+`, "'salary'", "'name'")
+}
+
+func TestAggregateFunc_MultiColumnOrderBy(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+
+	agg := JSON_AGG(name).ORDER_BY(salary.ASC(), name.DESC())
+
+	stmt := SELECT(
+		IntegerColumn("company_id"),
+		agg.AS("employees"),
+	).FROM(NewTable("public", "employee", "e", salary, name))
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT company_id AS "company_id",
+     json_agg((e.name) ORDER BY e.salary ASC, e.name DESC) AS "employees"
+FROM public.employee AS e;
+`)
+}
+
+func TestAggregateFunc_WithoutOrderBy(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+
+	agg := JSON_AGG(
+		Func("json_build_object", String("'salary'"), salary, String("'name'"), name),
+	)
+
+	stmt := SELECT(
+		IntegerColumn("company_id"),
+		agg.AS("employees"),
+	).FROM(NewTable("public", "employee", "e", salary, name))
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT company_id AS "company_id",
+     json_agg((json_build_object($1::text, e.salary, $2::text, e.name))) AS "employees"
+FROM public.employee AS e;
+`, "'salary'", "'name'")
+}
+
+func TestAggregateFunc_ArrayAgg(t *testing.T) {
+	name := StringColumn("name")
+
+	agg := ARRAY_AGG(name).ORDER_BY(name.ASC())
+
+	stmt := SELECT(
+		IntegerColumn("company_id"),
+		agg.AS("names"),
+	).FROM(NewTable("public", "employee", "e", name))
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT company_id AS "company_id",
+     array_agg((e.name) ORDER BY e.name ASC) AS "names"
+FROM public.employee AS e;
+`)
+}


### PR DESCRIPTION
Add ORDER BY support for aggregate functions.

## What
Introduces a generic `AggregateFunc` expression that serializes an embedded ORDER BY clause inside the function call:

```sql
json_agg(expr ORDER BY col)
```

Exposes `JSON_AGG` and `ARRAY_AGG` in the `postgres` package. Both accept a single `Expression` argument and offer `.ORDER_BY(... OrderByClause)` with full ASC/DESC/NULLS FIRST/LAST and multi-column support:

```go
JSON_AGG(
    Func("json_build_object",
        String("'salary'"), salary,
        String("'name'"), name,
    ),
).ORDER_BY(salary.ASC())
```

## Motivation
PostgreSQL aggregates commonly need ordered input (`json_agg`, `array_agg`, `string_agg`). Today this requires raw `Func()` + custom serialization; this makes it a first-class, type-safe API and reuses the existing `OrderByClause` machinery (`ASC()`, `DESC()`, `NULLS_LAST()`, etc.).

## Tests
- `TestAggregateFunc_JSON_AGG_OrderBy` — basic ASC
- `TestAggregateFunc_JSON_AGG_OrderByDescNullsLast` — DESC + NULLS LAST
- `TestAggregateFunc_MultiColumnOrderBy` — multiple ORDER BY expressions
- `TestAggregateFunc_WithoutOrderBy` — degrades to plain `json_agg(...)`
- `TestAggregateFunc_ArrayAgg` — second aggregate type