### PR TITLE
Add json and jsonb expression types with full separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # Test files
 gen
 .gentestdata
+.gentestdata2
 .tests/testdata/
 .gen
 .docker

--- a/generator/postgres/query_set.go
+++ b/generator/postgres/query_set.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/go-jet/jet/v2/generator/metadata"
 	postgresdialect "github.com/go-jet/jet/v2/postgres"
@@ -55,6 +56,15 @@ ORDER BY table_name;
 }
 
 func getColumnsMetaData(db *sql.DB, schemaName string, tableName string) ([]metadata.Column, error) {
+	// CockroachDB collapses the json type into jsonb, so clients can't tell a
+	// `json` from a `jsonb` column. Distinguish it so the SQL builder maps both
+	// to a single Json column type there (jsonb operators don't apply anyway).
+	var sourceDialect = postgresdialect.Dialect.Name() // "PostgreSQL"
+	var serverVersion string
+	if err := db.QueryRow("SELECT version()").Scan(&serverVersion); err == nil && strings.Contains(serverVersion, "CockroachDB") {
+		sourceDialect = "CockroachDB"
+	}
+
 	query := `
 select  
     attr.attname as "column.Name",
@@ -96,7 +106,7 @@ order by
     attr.attnum;
 `
 	var columns []metadata.Column
-	_, err := qrm.Query(context.Background(), db, query, []interface{}{schemaName, tableName, postgresdialect.Dialect.Name()}, &columns)
+	_, err := qrm.Query(context.Background(), db, query, []interface{}{schemaName, tableName, sourceDialect}, &columns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query '%s' columns metadata: %w", tableName, err)
 	}

--- a/generator/template/sql_builder_template.go
+++ b/generator/template/sql_builder_template.go
@@ -179,6 +179,11 @@ func getSqlBuilderColumnType(columnMetaData metadata.Column) string {
 			return "String"
 		}
 
+		// json/jsonb arrays have no dedicated jet column type, fall back to StringArray
+		if columnType == "Json" || columnType == "Jsonb" {
+			return "StringArray"
+		}
+
 		columnType = columnType + "Array"
 	}
 
@@ -209,9 +214,20 @@ func sqlToColumnType(columnMetaData metadata.Column) string {
 	case "interval":
 		return "Interval"
 	case "user-defined", "enum", "text", "character", "character varying", "uuid",
-		"tsvector", "bit", "bit varying", "money", "json", "jsonb", "xml", "point", "line", "ARRAY",
+		"tsvector", "bit", "bit varying", "money", "xml", "point", "line", "ARRAY",
 		"char", "varchar", "nvarchar", "bpchar", "varbit",
 		"tinytext", "mediumtext", "longtext": // MySQL
+		return "String"
+	case "json", "jsonb":
+		// json/jsonb column types are only exposed as Json/Jsonb for PostgreSQL.
+		// MySQL's json type has no jsonb distinction or json-only operators, so it
+		// stays a String column there.
+		if columnMetaData.DataType.SourceDialect == "PostgreSQL" {
+			if strings.ToLower(columnMetaData.DataType.Name) == "jsonb" {
+				return "Jsonb"
+			}
+			return "Json"
+		}
 		return "String"
 	case "bytea": // postgres
 		return "Bytea"

--- a/generator/template/sql_builder_template.go
+++ b/generator/template/sql_builder_template.go
@@ -221,14 +221,19 @@ func sqlToColumnType(columnMetaData metadata.Column) string {
 	case "json", "jsonb":
 		// json/jsonb column types are only exposed as Json/Jsonb for PostgreSQL.
 		// MySQL's json type has no jsonb distinction or json-only operators, so it
-		// stays a String column there.
-		if columnMetaData.DataType.SourceDialect == "PostgreSQL" {
+		// stays a String column there. CockroachDB collapses json into jsonb, so
+		// both map to a single Json column type there (no jsonb operator support).
+		switch columnMetaData.DataType.SourceDialect {
+		case "CockroachDB":
+			return "Json"
+		case "PostgreSQL":
 			if strings.ToLower(columnMetaData.DataType.Name) == "jsonb" {
 				return "Jsonb"
 			}
 			return "Json"
+		default:
+			return "String"
 		}
-		return "String"
 	case "bytea": // postgres
 		return "Bytea"
 	case "binary", "varbinary", "tinyblob", "mediumblob", "longblob", "blob": // mysql and sqlite

--- a/internal/jet/aggregate_functions.go
+++ b/internal/jet/aggregate_functions.go
@@ -1,0 +1,62 @@
+package jet
+
+// AggregateFunc is a named aggregate function (e.g. json_agg) with an optional
+// embedded ORDER BY clause. The ORDER BY is serialized inside the function call:
+//
+//	json_agg(expr ORDER BY col)
+//
+// which is the PostgreSQL syntax for ordering the input rows of an aggregate.
+type AggregateFunc struct {
+	Expression
+
+	name     string
+	argument Expression
+	orderBy  []OrderByClause
+}
+
+// ORDER_BY sets the ORDER BY clause of the aggregate input rows.
+func (a *AggregateFunc) ORDER_BY(orderBy ...OrderByClause) Expression {
+	a.orderBy = orderBy
+	return a.Expression
+}
+
+// NewAggregateFunc creates a named aggregate function expression. The returned
+// Expression carries an optional embedded ORDER BY clause settable via ORDER_BY:
+//
+//	json_agg(expr ORDER BY col)
+func NewAggregateFunc(name string, argument Expression) *AggregateFunc {
+	aggFunc := &AggregateFunc{
+		name:     name,
+		argument: argument,
+	}
+	aggFunc.Expression = newExpression(newAggregateFuncSerializer(aggFunc))
+	return aggFunc
+}
+
+func newAggregateFuncSerializer(aggFunc *AggregateFunc) *aggregateFuncSerializer {
+	return &aggregateFuncSerializer{AggregateFunc: aggFunc}
+}
+
+type aggregateFuncSerializer struct {
+	*AggregateFunc
+}
+
+func (a *aggregateFuncSerializer) serialize(statement StatementType, out *SQLBuilder, options ...SerializeOption) {
+	out.WriteString(a.name + "(")
+
+	if a.argument != nil {
+		wrap(a.argument).serialize(statement, out, FallTrough(options)...)
+	}
+
+	if len(a.orderBy) > 0 {
+		out.WriteString(" ORDER BY ")
+		for i, orderBy := range a.orderBy {
+			if i > 0 {
+				out.WriteString(", ")
+			}
+			orderBy.serializeForOrderBy(statement, out)
+		}
+	}
+
+	out.WriteString(")")
+}

--- a/internal/jet/column_types.go
+++ b/internal/jet/column_types.go
@@ -223,6 +223,96 @@ func StringColumn(name string) ColumnString {
 
 //------------------------------------------------------//
 
+// ColumnJson is interface for SQL json columns.
+type ColumnJson interface {
+	JsonExpression
+	Column
+
+	From(subQuery SelectTable) ColumnJson
+	SET(jsonExp JsonExpression) ColumnAssigment
+}
+
+type jsonColumnImpl struct {
+	jsonInterfaceImpl
+
+	*ColumnExpressionImpl
+}
+
+func (i *jsonColumnImpl) fromImpl(subQuery SelectTable) Projection {
+	return i.From(subQuery)
+}
+
+func (i *jsonColumnImpl) From(subQuery SelectTable) ColumnJson {
+	newJsonColumn := JsonColumn(i.name)
+	newJsonColumn.setTableName(i.tableName)
+	newJsonColumn.setSubQuery(subQuery)
+
+	return newJsonColumn
+}
+
+func (i *jsonColumnImpl) SET(jsonExp JsonExpression) ColumnAssigment {
+	return columnAssigmentImpl{
+		column:   i,
+		toAssign: jsonExp,
+	}
+}
+
+// JsonColumn creates named json column.
+func JsonColumn(name string) ColumnJson {
+	jsonColumn := &jsonColumnImpl{}
+	jsonColumn.jsonInterfaceImpl.root = jsonColumn
+	jsonColumn.ColumnExpressionImpl = NewColumnImpl(name, "", jsonColumn)
+
+	return jsonColumn
+}
+
+//------------------------------------------------------//
+
+// ColumnJsonb is interface for SQL jsonb columns.
+type ColumnJsonb interface {
+	JsonbExpression
+	Column
+
+	From(subQuery SelectTable) ColumnJsonb
+	SET(jsonbExp JsonbExpression) ColumnAssigment
+}
+
+type jsonbColumnImpl struct {
+	jsonbInterfaceImpl
+
+	*ColumnExpressionImpl
+}
+
+func (i *jsonbColumnImpl) fromImpl(subQuery SelectTable) Projection {
+	return i.From(subQuery)
+}
+
+func (i *jsonbColumnImpl) From(subQuery SelectTable) ColumnJsonb {
+	newJsonbColumn := JsonbColumn(i.name)
+	newJsonbColumn.setTableName(i.tableName)
+	newJsonbColumn.setSubQuery(subQuery)
+
+	return newJsonbColumn
+}
+
+func (i *jsonbColumnImpl) SET(jsonbExp JsonbExpression) ColumnAssigment {
+	return columnAssigmentImpl{
+		column:   i,
+		toAssign: jsonbExp,
+	}
+}
+
+// JsonbColumn creates named jsonb column.
+func JsonbColumn(name string) ColumnJsonb {
+	jsonbColumn := &jsonbColumnImpl{}
+	jsonbColumn.jsonbInterfaceImpl.root = jsonbColumn
+	jsonbColumn.ColumnExpressionImpl = NewColumnImpl(name, "", jsonbColumn)
+
+	return jsonbColumn
+}
+
+//------------------------------------------------------//
+
 // ColumnBlob is interface for binary data types (bytea, binary, blob, etc...)
 type ColumnBlob interface {
 	BlobExpression

--- a/internal/jet/json_expression.go
+++ b/internal/jet/json_expression.go
@@ -1,0 +1,249 @@
+package jet
+
+// JsonExpression is an expression of the PostgreSQL json type. The jsonb type is
+// modelled separately (JsonbExpression) so that jsonb-only operators are only
+// available on jsonb expressions at compile time; converting between the two
+// requires an explicit cast.
+type JsonExpression interface {
+	Expression
+	isJson()
+
+	// Arrow returns a representation of "lhs -> rhs" (extract JSON object field by key).
+	Arrow(rhs Expression) JsonExpression
+	// ArrowText returns a representation of "lhs ->> rhs" (extract JSON object field by key as text).
+	ArrowText(rhs Expression) StringExpression
+	// HashArrow returns a representation of "lhs #> rhs" (extract JSON sub-object at the specified path).
+	HashArrow(rhs Expression) JsonExpression
+	// HashArrowText returns a representation of "lhs #>> rhs" (extract JSON sub-object at the specified path as text).
+	HashArrowText(rhs Expression) StringExpression
+	// Concat returns a representation of "lhs || rhs".
+	Concat(rhs JsonExpression) JsonExpression
+
+	EQ(rhs JsonExpression) BoolExpression
+	NOT_EQ(rhs JsonExpression) BoolExpression
+	IS_DISTINCT_FROM(rhs JsonExpression) BoolExpression
+	IS_NOT_DISTINCT_FROM(rhs JsonExpression) BoolExpression
+}
+
+type jsonInterfaceImpl struct {
+	root JsonExpression
+}
+
+func (j *jsonInterfaceImpl) isJson() {}
+
+func (j *jsonInterfaceImpl) Arrow(rhs Expression) JsonExpression {
+	return newBinaryJsonOperatorExpression(j.root, rhs, "->")
+}
+
+func (j *jsonInterfaceImpl) ArrowText(rhs Expression) StringExpression {
+	return StringExp(NewBinaryOperatorExpression(j.root, rhs, "->>"))
+}
+
+func (j *jsonInterfaceImpl) HashArrow(rhs Expression) JsonExpression {
+	return newBinaryJsonOperatorExpression(j.root, rhs, "#>")
+}
+
+func (j *jsonInterfaceImpl) HashArrowText(rhs Expression) StringExpression {
+	return StringExp(NewBinaryOperatorExpression(j.root, rhs, "#>>"))
+}
+
+func (j *jsonInterfaceImpl) Concat(rhs JsonExpression) JsonExpression {
+	return newBinaryJsonOperatorExpression(j.root, rhs, "||")
+}
+
+func (j *jsonInterfaceImpl) EQ(rhs JsonExpression) BoolExpression {
+	return Eq(j.root, rhs)
+}
+
+func (j *jsonInterfaceImpl) NOT_EQ(rhs JsonExpression) BoolExpression {
+	return NotEq(j.root, rhs)
+}
+
+func (j *jsonInterfaceImpl) IS_DISTINCT_FROM(rhs JsonExpression) BoolExpression {
+	return IsDistinctFrom(j.root, rhs)
+}
+
+func (j *jsonInterfaceImpl) IS_NOT_DISTINCT_FROM(rhs JsonExpression) BoolExpression {
+	return IsNotDistinctFrom(j.root, rhs)
+}
+
+func newBinaryJsonOperatorExpression(lhs, rhs Expression, operator string) JsonExpression {
+	root := NewBinaryOperatorExpression(lhs, rhs, operator)
+	jsonExp := &jsonExpressionWrapper{
+		jsonInterfaceImpl: jsonInterfaceImpl{},
+		Expression:        root,
+	}
+	jsonExp.jsonInterfaceImpl.root = jsonExp
+	root.setRoot(jsonExp)
+	return jsonExp
+}
+
+// ---------------------------------------------------//
+
+type jsonExpressionWrapper struct {
+	jsonInterfaceImpl
+	Expression
+}
+
+func newJsonExpressionWrap(expression Expression) JsonExpression {
+	jsonExpressionWrap := &jsonExpressionWrapper{
+		jsonInterfaceImpl: jsonInterfaceImpl{},
+		Expression:        expression,
+	}
+	jsonExpressionWrap.jsonInterfaceImpl.root = jsonExpressionWrap
+	expression.setRoot(jsonExpressionWrap)
+	return jsonExpressionWrap
+}
+
+// JsonExp is a json expression wrapper around arbitrary expression.
+// Allows go compiler to see any expression as json expression.
+// Does not add sql cast to generated sql builder output.
+func JsonExp(expression Expression) JsonExpression {
+	return newJsonExpressionWrap(expression)
+}
+
+//----------------- jsonb -----------------//
+
+// JsonbExpression is an expression of the PostgreSQL jsonb type. jsonb-only
+// operators (containment, existence, deletion) are only available here, so they
+// cannot be applied to a json expression without an explicit cast.
+type JsonbExpression interface {
+	Expression
+	isJsonb()
+
+	// Arrow returns a representation of "lhs -> rhs" (extract JSON object field by key).
+	Arrow(rhs Expression) JsonbExpression
+	// ArrowText returns a representation of "lhs ->> rhs" (extract JSON object field by key as text).
+	ArrowText(rhs Expression) StringExpression
+	// HashArrow returns a representation of "lhs #> rhs" (extract JSON sub-object at the specified path).
+	HashArrow(rhs Expression) JsonbExpression
+	// HashArrowText returns a representation of "lhs #>> rhs" (extract JSON sub-object at the specified path as text).
+	HashArrowText(rhs Expression) StringExpression
+	// Concat returns a representation of "lhs || rhs".
+	Concat(rhs JsonbExpression) JsonbExpression
+
+	// Contains returns a representation of "lhs @> rhs" (lhs contains rhs).
+	Contains(rhs JsonbExpression) BoolExpression
+	// IsContainedBy returns a representation of "lhs <@ rhs" (lhs is contained by rhs).
+	IsContainedBy(rhs JsonbExpression) BoolExpression
+	// Exists returns a representation of "lhs ? rhs" (string exists as a top-level key).
+	Exists(rhs StringExpression) BoolExpression
+	// ExistsAny returns a representation of "lhs ?| rhs" (any of the strings exist as top-level keys).
+	ExistsAny(rhs StringExpression) BoolExpression
+	// ExistsAll returns a representation of "lhs ?& rhs" (all of the strings exist as top-level keys).
+	ExistsAll(rhs StringExpression) BoolExpression
+	// Remove returns a representation of "lhs - rhs" (deletes key or element).
+	Remove(rhs Expression) JsonbExpression
+	// RemovePath returns a representation of "lhs #- rhs" (delete path).
+	RemovePath(rhs Expression) JsonbExpression
+
+	EQ(rhs JsonbExpression) BoolExpression
+	NOT_EQ(rhs JsonbExpression) BoolExpression
+	IS_DISTINCT_FROM(rhs JsonbExpression) BoolExpression
+	IS_NOT_DISTINCT_FROM(rhs JsonbExpression) BoolExpression
+}
+
+type jsonbInterfaceImpl struct {
+	root JsonbExpression
+}
+
+func (j *jsonbInterfaceImpl) isJsonb() {}
+
+func (j *jsonbInterfaceImpl) Arrow(rhs Expression) JsonbExpression {
+	return newBinaryJsonbOperatorExpression(j.root, rhs, "->")
+}
+
+func (j *jsonbInterfaceImpl) ArrowText(rhs Expression) StringExpression {
+	return StringExp(NewBinaryOperatorExpression(j.root, rhs, "->>"))
+}
+
+func (j *jsonbInterfaceImpl) HashArrow(rhs Expression) JsonbExpression {
+	return newBinaryJsonbOperatorExpression(j.root, rhs, "#>")
+}
+
+func (j *jsonbInterfaceImpl) HashArrowText(rhs Expression) StringExpression {
+	return StringExp(NewBinaryOperatorExpression(j.root, rhs, "#>>"))
+}
+
+func (j *jsonbInterfaceImpl) Concat(rhs JsonbExpression) JsonbExpression {
+	return newBinaryJsonbOperatorExpression(j.root, rhs, "||")
+}
+
+func (j *jsonbInterfaceImpl) Contains(rhs JsonbExpression) BoolExpression {
+	return newBinaryBoolOperatorExpression(j.root, rhs, "@>")
+}
+
+func (j *jsonbInterfaceImpl) IsContainedBy(rhs JsonbExpression) BoolExpression {
+	return newBinaryBoolOperatorExpression(j.root, rhs, "<@")
+}
+
+func (j *jsonbInterfaceImpl) Exists(rhs StringExpression) BoolExpression {
+	return newBinaryBoolOperatorExpression(j.root, rhs, "?")
+}
+
+func (j *jsonbInterfaceImpl) ExistsAny(rhs StringExpression) BoolExpression {
+	return newBinaryBoolOperatorExpression(j.root, rhs, "?|")
+}
+
+func (j *jsonbInterfaceImpl) ExistsAll(rhs StringExpression) BoolExpression {
+	return newBinaryBoolOperatorExpression(j.root, rhs, "?&")
+}
+
+func (j *jsonbInterfaceImpl) Remove(rhs Expression) JsonbExpression {
+	return newBinaryJsonbOperatorExpression(j.root, rhs, "-")
+}
+
+func (j *jsonbInterfaceImpl) RemovePath(rhs Expression) JsonbExpression {
+	return newBinaryJsonbOperatorExpression(j.root, rhs, "#-")
+}
+
+func (j *jsonbInterfaceImpl) EQ(rhs JsonbExpression) BoolExpression {
+	return Eq(j.root, rhs)
+}
+
+func (j *jsonbInterfaceImpl) NOT_EQ(rhs JsonbExpression) BoolExpression {
+	return NotEq(j.root, rhs)
+}
+
+func (j *jsonbInterfaceImpl) IS_DISTINCT_FROM(rhs JsonbExpression) BoolExpression {
+	return IsDistinctFrom(j.root, rhs)
+}
+
+func (j *jsonbInterfaceImpl) IS_NOT_DISTINCT_FROM(rhs JsonbExpression) BoolExpression {
+	return IsNotDistinctFrom(j.root, rhs)
+}
+
+func newBinaryJsonbOperatorExpression(lhs, rhs Expression, operator string) JsonbExpression {
+	root := NewBinaryOperatorExpression(lhs, rhs, operator)
+	jsonbExp := &jsonbExpressionWrapper{
+		jsonbInterfaceImpl: jsonbInterfaceImpl{},
+		Expression:         root,
+	}
+	jsonbExp.jsonbInterfaceImpl.root = jsonbExp
+	root.setRoot(jsonbExp)
+	return jsonbExp
+}
+
+// ---------------------------------------------------//
+
+type jsonbExpressionWrapper struct {
+	jsonbInterfaceImpl
+	Expression
+}
+
+func newJsonbExpressionWrap(expression Expression) JsonbExpression {
+	jsonbExpressionWrap := &jsonbExpressionWrapper{
+		jsonbInterfaceImpl: jsonbInterfaceImpl{},
+		Expression:         expression,
+	}
+	jsonbExpressionWrap.jsonbInterfaceImpl.root = jsonbExpressionWrap
+	expression.setRoot(jsonbExpressionWrap)
+	return jsonbExpressionWrap
+}
+
+// JsonbExp is a jsonb expression wrapper around arbitrary expression.
+// Allows go compiler to see any expression as jsonb expression.
+// Does not add sql cast to generated sql builder output.
+func JsonbExp(expression Expression) JsonbExpression {
+	return newJsonbExpressionWrap(expression)
+}

--- a/postgres/aggregate_functions.go
+++ b/postgres/aggregate_functions.go
@@ -1,0 +1,23 @@
+package postgres
+
+import "github.com/go-jet/jet/v2/internal/jet"
+
+// JSON_AGG returns a json_agg aggregate expression. Aggregate input rows can be
+// ordered with ORDER_BY, e.g.:
+//
+//	JSON_AGG(expr).ORDER_BY(Column.ASC())
+//
+// which serializes to json_agg(expr ORDER BY column ASC).
+func JSON_AGG(expression Expression) *jet.AggregateFunc {
+	return jet.NewAggregateFunc("json_agg", expression)
+}
+
+// JSONB_AGG returns a jsonb_agg aggregate expression with optional ORDER BY.
+func JSONB_AGG(expression Expression) *jet.AggregateFunc {
+	return jet.NewAggregateFunc("jsonb_agg", expression)
+}
+
+// ARRAY_AGG returns an array_agg aggregate expression with optional ORDER BY.
+func ARRAY_AGG(expression Expression) *jet.AggregateFunc {
+	return jet.NewAggregateFunc("array_agg", expression)
+}

--- a/postgres/cast.go
+++ b/postgres/cast.go
@@ -71,6 +71,16 @@ func (b *cast) AS_TEXT() StringExpression {
 	return StringExp(b.AS("text"))
 }
 
+// AS_JSON casts expression AS json type
+func (b *cast) AS_JSON() JsonExpression {
+	return JsonExp(b.AS("json"))
+}
+
+// AS_JSONB casts expression AS jsonb type
+func (b *cast) AS_JSONB() JsonbExpression {
+	return JsonbExp(b.AS("jsonb"))
+}
+
 // AS_CHAR casts expression AS a character type
 func (b *cast) AS_CHAR(length ...int) StringExpression {
 	if len(length) > 0 {

--- a/postgres/columns.go
+++ b/postgres/columns.go
@@ -23,6 +23,18 @@ type ColumnString = jet.ColumnString
 // StringColumn creates named string column.
 var StringColumn = jet.StringColumn
 
+// ColumnJson is interface for SQL json columns.
+type ColumnJson = jet.ColumnJson
+
+// JsonColumn creates named json column.
+var JsonColumn = jet.JsonColumn
+
+// ColumnJsonb is interface for SQL jsonb columns.
+type ColumnJsonb = jet.ColumnJsonb
+
+// JsonbColumn creates named jsonb column.
+var JsonbColumn = jet.JsonbColumn
+
 // ColumnBytea is interface for bytea columns
 type ColumnBytea = jet.ColumnBlob
 

--- a/postgres/expressions.go
+++ b/postgres/expressions.go
@@ -15,6 +15,12 @@ type BoolExpression = jet.BoolExpression
 // StringExpression interface
 type StringExpression = jet.StringExpression
 
+// JsonExpression interface
+type JsonExpression = jet.JsonExpression
+
+// JsonbExpression interface
+type JsonbExpression = jet.JsonbExpression
+
 type ByteaExpression = jet.BlobExpression
 
 // NumericExpression interface
@@ -89,6 +95,14 @@ var TimeExp = jet.TimeExp
 // Allows go compiler to see any expression as string expression.
 // Does not add sql cast to generated sql builder output.
 var StringExp = jet.StringExp
+
+// JsonExp is a json expression wrapper around arbitrary expression.
+// Allows go compiler to see any expression as a json expression.
+// Does not add sql cast to generated sql builder output.
+var JsonExp = jet.JsonExp
+
+// JsonbExp is a jsonb expression wrapper around arbitrary expression.
+var JsonbExp = jet.JsonbExp
 
 // ByteaExp is blob expression wrapper around arbitrary expression.
 // Allows go compiler to see any expression as string expression.

--- a/postgres/json_expression_test.go
+++ b/postgres/json_expression_test.go
@@ -1,0 +1,187 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/go-jet/jet/v2/internal/testutils"
+)
+
+func TestJsonExpression_Operators(t *testing.T) {
+	data := JsonColumn("data")
+	key := StringColumn("key")
+	doc := NewTable("public", "doc", "", data, key)
+
+	stmt := SELECT(
+		data.Arrow(key).AS("v1"),
+		data.ArrowText(key).AS("v2"),
+		data.HashArrow(StringArrayColumn("path")).AS("v3"),
+		data.HashArrowText(StringArrayColumn("path")).AS("v4"),
+		data.Concat(JSON([]byte(`{"b":2}`))).AS("v5"),
+	).FROM(doc)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT (doc.data -> doc.key) AS "v1",
+     (doc.data ->> doc.key) AS "v2",
+     (doc.data #> path) AS "v3",
+     (doc.data #>> path) AS "v4",
+     (doc.data || $1::json) AS "v5"
+FROM public.doc;
+`, []byte(`{"b":2}`))
+}
+
+func TestJsonbColumn_Operators(t *testing.T) {
+	data := JsonColumn("data")
+	dataB := JsonbColumn("data_b")
+	key := StringColumn("key")
+	doc := NewTable("public", "doc", "", data, dataB, key)
+
+	stmt := SELECT(
+		dataB.Arrow(key).AS("v1"),
+		dataB.ArrowText(key).AS("v2"),
+		dataB.HashArrowText(StringArrayColumn("path")).AS("v3"),
+		dataB.Contains(JSONB([]byte(`{"a":1}`))).AS("v4"),
+		dataB.IsContainedBy(JSONB([]byte(`{"a":1}`))).AS("v5"),
+		dataB.Exists(key).AS("v6"),
+		dataB.ExistsAny(key).AS("v7"),
+		dataB.ExistsAll(key).AS("v8"),
+		dataB.Remove(key).AS("v9"),
+		dataB.RemovePath(StringArrayColumn("path")).AS("v10"),
+		dataB.Concat(JSONB([]byte(`{"b":2}`))).AS("v11"),
+	).FROM(doc)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT (doc.data_b -> doc.key) AS "v1",
+     (doc.data_b ->> doc.key) AS "v2",
+     (doc.data_b #>> path) AS "v3",
+     (doc.data_b @> $1::jsonb) AS "v4",
+     (doc.data_b <@ $2::jsonb) AS "v5",
+     (doc.data_b ? doc.key) AS "v6",
+     (doc.data_b ?| doc.key) AS "v7",
+     (doc.data_b ?& doc.key) AS "v8",
+     (doc.data_b - doc.key) AS "v9",
+     (doc.data_b #- path) AS "v10",
+     (doc.data_b || $3::jsonb) AS "v11"
+FROM public.doc;
+`, []byte(`{"a":1}`), []byte(`{"a":1}`), []byte(`{"b":2}`))
+}
+
+func TestJsonToJsonbRequiresExplicitCast(t *testing.T) {
+	// jsonb-only operators are not available on a json column; converting to
+	// jsonb requires an explicit cast, which is the intended separation.
+	data := JsonColumn("data")
+	key := StringColumn("key")
+	doc := NewTable("public", "doc", "", data, key)
+
+	stmt := SELECT(
+		CAST(data).AS_JSONB().Exists(key).AS("v1"),
+		CAST(data).AS_JSONB().Contains(JSONB([]byte(`{"a":1}`))).AS("v2"),
+	).FROM(doc)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT (doc.data::jsonb ? doc.key) AS "v1",
+     (doc.data::jsonb @> $1::jsonb) AS "v2"
+FROM public.doc;
+`, []byte(`{"a":1}`))
+}
+
+func TestJsonLiterals(t *testing.T) {
+	stmt := SELECT(
+		JSON([]byte(`{"a":1}`)).AS("j"),
+		JSONB([]byte(`{"b":2}`)).AS("jb"),
+	)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT $1::json AS "j",
+     $2::jsonb AS "jb";
+`, []byte(`{"a":1}`), []byte(`{"b":2}`))
+}
+
+func TestJsonFunctions(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+	doc := NewTable("public", "doc", "", salary, name)
+
+	stmt := SELECT(
+		JSON_BUILD_OBJECT(Text("salary"), salary, Text("name"), name).AS("obj"),
+		JSONB_BUILD_OBJECT(Text("salary"), salary).AS("objb"),
+		JSON_BUILD_ARRAY(salary, name).AS("arr"),
+		JSONB_BUILD_ARRAY(salary).AS("arrb"),
+		TO_JSON(salary).AS("tj"),
+		TO_JSONB(salary).AS("tjb"),
+		JSON_ARRAY_LENGTH(JSON_BUILD_ARRAY(salary)).AS("len"),
+		JSONB_PRETTY(TO_JSONB(salary)).AS("pretty"),
+	).FROM(doc)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT json_build_object($1::text, doc.salary, $2::text, doc.name) AS "obj",
+     jsonb_build_object($3::text, doc.salary) AS "objb",
+     json_build_array(doc.salary, doc.name) AS "arr",
+     jsonb_build_array(doc.salary) AS "arrb",
+     to_json(doc.salary) AS "tj",
+     to_jsonb(doc.salary) AS "tjb",
+     json_array_length(json_build_array(doc.salary)) AS "len",
+     jsonb_pretty(to_jsonb(doc.salary)) AS "pretty"
+FROM public.doc;
+`, "salary", "name", "salary")
+}
+
+func TestJsonBuildObjectDynamicKeys(t *testing.T) {
+	// a text column can be a key: json_build_object(p.id, p.salary)
+	id := StringColumn("id")
+	salary := IntegerColumn("salary")
+	emp := NewTable("public", "emp", "p", id, salary)
+
+	stmt := SELECT(
+		JSON_BUILD_OBJECT(id, salary).AS("obj"),
+	).FROM(emp)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT json_build_object(p.id, p.salary) AS "obj"
+FROM public.emp AS p;
+`)
+}
+
+func TestJsonbFunctionResultSupportsJsonbOperators(t *testing.T) {
+	// a jsonb_build_object(...) result is a jsonb expression, so jsonb-only ops work
+	stmt := SELECT(
+		JSONB_BUILD_OBJECT(Text("a"), Int(1)).Contains(JSONB([]byte(`{"a":1}`))).AS("c"),
+	)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT (jsonb_build_object($1::text, $2) @> $3::jsonb) AS "c";
+`, "a", int64(1), []byte(`{"a":1}`))
+}
+
+func TestJsonAgg(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+	emp := NewTable("public", "emp", "e", salary, name)
+
+	stmt := SELECT(
+		JSON_AGG(
+			JSON_BUILD_OBJECT(Text("salary"), salary, Text("name"), name),
+		).ORDER_BY(salary.ASC()).AS("employees"),
+	).FROM(emp)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT json_agg((json_build_object($1::text, e.salary, $2::text, e.name)) ORDER BY e.salary ASC) AS "employees"
+FROM public.emp AS e;
+`, "salary", "name")
+}
+
+func TestJsonbAgg(t *testing.T) {
+	salary := IntegerColumn("salary")
+	name := StringColumn("name")
+	emp := NewTable("public", "emp", "e", salary, name)
+
+	stmt := SELECT(
+		JSONB_AGG(
+			JSONB_BUILD_OBJECT(Text("salary"), salary, Text("name"), name),
+		).ORDER_BY(name.DESC()).AS("employees"),
+	).FROM(emp)
+
+	testutils.AssertStatementSql(t, stmt, `
+SELECT jsonb_agg((jsonb_build_object($1::text, e.salary, $2::text, e.name)) ORDER BY e.name DESC) AS "employees"
+FROM public.emp AS e;
+`, "salary", "name")
+}

--- a/postgres/json_functions.go
+++ b/postgres/json_functions.go
@@ -1,0 +1,79 @@
+package postgres
+
+// JSON_BUILD_OBJECT returns a json_build_object expression (json type). It takes
+// alternating key/value arguments, e.g.:
+//
+//	JSON_BUILD_OBJECT(Text("salary"), salary, Text("name"), name)
+//
+// which serializes to json_build_object($1::text, salary, $2::text, name).
+// Keys and values are arbitrary expressions, so dynamic keys are supported:
+//
+//	JSON_BUILD_OBJECT(p.employeeKey, p.salary)
+func JSON_BUILD_OBJECT(args ...Expression) JsonExpression {
+	return JsonExp(Func("json_build_object", args...))
+}
+
+// JSONB_BUILD_OBJECT returns a jsonb_build_object expression (jsonb type).
+// See JSON_BUILD_OBJECT for the argument form.
+func JSONB_BUILD_OBJECT(args ...Expression) JsonbExpression {
+	return JsonbExp(Func("jsonb_build_object", args...))
+}
+
+// JSON_BUILD_ARRAY returns a json_build_array expression (json type).
+func JSON_BUILD_ARRAY(args ...Expression) JsonExpression {
+	return JsonExp(Func("json_build_array", args...))
+}
+
+// JSONB_BUILD_ARRAY returns a jsonb_build_array expression (jsonb type).
+func JSONB_BUILD_ARRAY(args ...Expression) JsonbExpression {
+	return JsonbExp(Func("jsonb_build_array", args...))
+}
+
+// TO_JSON returns a to_json expression (json type) that converts any value to json.
+func TO_JSON(value Expression) JsonExpression {
+	return JsonExp(Func("to_json", value))
+}
+
+// TO_JSONB returns a to_jsonb expression (jsonb type) that converts any value to jsonb.
+func TO_JSONB(value Expression) JsonbExpression {
+	return JsonbExp(Func("to_jsonb", value))
+}
+
+// JSON_ARRAY_LENGTH returns a json_array_length expression (integer result).
+func JSON_ARRAY_LENGTH(value JsonExpression) IntegerExpression {
+	return IntExp(Func("json_array_length", value))
+}
+
+// JSONB_ARRAY_LENGTH returns a jsonb_array_length expression (integer result).
+func JSONB_ARRAY_LENGTH(value JsonbExpression) IntegerExpression {
+	return IntExp(Func("jsonb_array_length", value))
+}
+
+// JSON_EXTRACT_PATH returns a json_extract_path expression (json type) that
+// extracts the JSON sub-object at the specified path.
+func JSON_EXTRACT_PATH(value JsonExpression, pathElems ...Expression) JsonExpression {
+	return JsonExp(Func("json_extract_path", append([]Expression{value}, pathElems...)...))
+}
+
+// JSONB_EXTRACT_PATH returns a jsonb_extract_path expression (jsonb type) that
+// extracts the JSON sub-object at the specified path.
+func JSONB_EXTRACT_PATH(value JsonbExpression, pathElems ...Expression) JsonbExpression {
+	return JsonbExp(Func("jsonb_extract_path", append([]Expression{value}, pathElems...)...))
+}
+
+// JSON_OBJECT returns a json_object expression (json type). It takes alternating
+// key/value text arguments.
+func JSON_OBJECT(args ...Expression) JsonExpression {
+	return JsonExp(Func("json_object", args...))
+}
+
+// JSONB_OBJECT returns a jsonb_object expression (jsonb type).
+func JSONB_OBJECT(args ...Expression) JsonbExpression {
+	return JsonbExp(Func("jsonb_object", args...))
+}
+
+// JSONB_PRETTY returns a jsonb_pretty expression (text result) that adds
+// indentation to the given jsonb value.
+func JSONB_PRETTY(value JsonbExpression) StringExpression {
+	return StringExp(Func("jsonb_pretty", value))
+}

--- a/postgres/literal.go
+++ b/postgres/literal.go
@@ -118,14 +118,28 @@ func VarChar(length ...int) func(value string) StringExpression {
 	}
 }
 
+// JSON is a parameter constructor for the PostgreSQL json type. It accepts a
+// []byte, json.RawMessage or string holding valid JSON and adds an explicit
+// placeholder type cast to json in the generated query, such as `$1::json`.
+func JSON(value []byte) JsonExpression {
+	return CAST(jet.Literal(value)).AS_JSON()
+}
+
+// JSONB is a parameter constructor for the PostgreSQL jsonb type. It accepts a
+// []byte, json.RawMessage or string holding valid JSON and adds an explicit
+// placeholder type cast to jsonb in the generated query, such as `$1::jsonb`.
+func JSONB(value []byte) JsonbExpression {
+	return CAST(jet.Literal(value)).AS_JSONB()
+}
+
 // Json creates new json literal expression
-func Json(value interface{}) StringExpression {
+func Json(value interface{}) JsonExpression {
 	switch value.(type) {
 	case string, []byte:
 	default:
-		panic("Bytea parameter value has to be of the type string or []byte")
+		panic("Json parameter value has to be of the type string or []byte")
 	}
-	return StringExp(CAST(jet.Literal(value)).AS("json"))
+	return JsonExp(CAST(jet.Literal(value)).AS("json"))
 }
 
 // UUID is a helper function to create string literal expression from uuid object

--- a/tests/postgres/generator_test.go
+++ b/tests/postgres/generator_test.go
@@ -1244,9 +1244,13 @@ func newAllTypesTableImpl(schemaName, tableName, alias string) allTypesTable {
 
 // CockroachDB collapses the json type into jsonb, so its json-ish columns are
 // all generated as ColumnJson (postgres keeps json and jsonb distinct).
+// The generator also emits the constructor as JsonColumn(...) for those columns,
+// so both the field type and the constructor must be remapped.
 var allTypesTableContentCockroach = strings.ReplaceAll(
-	allTypesTableContent,
-	"postgres.ColumnJsonb", "postgres.ColumnJson")
+	strings.ReplaceAll(
+		allTypesTableContent,
+		"postgres.ColumnJsonb", "postgres.ColumnJson"),
+	"postgres.JsonbColumn(", "postgres.JsonColumn(")
 
 var sampleRangeTableContent = `
 //

--- a/tests/postgres/generator_test.go
+++ b/tests/postgres/generator_test.go
@@ -805,7 +805,11 @@ func TestGeneratedAllTypesSQLBuilderFiles(t *testing.T) {
 		testutils.AssertFileNamesEqual(t, tableDir, postgresSqlBuilders...)
 	}
 
-	testutils.AssertFileContent(t, tableDir+"/all_types.go", allTypesTableContent)
+	content := allTypesTableContent
+	if sourceIsCockroachDB() {
+		content = allTypesTableContentCockroach
+	}
+	testutils.AssertFileContent(t, tableDir+"/all_types.go", content)
 
 	if sourceIsPostgres() {
 		testutils.AssertFileContent(t, tableDir+"/sample_ranges.go", sampleRangeTableContent)
@@ -1237,6 +1241,12 @@ func newAllTypesTableImpl(schemaName, tableName, alias string) allTypesTable {
 	}
 }
 `
+
+// CockroachDB collapses the json type into jsonb, so its json-ish columns are
+// all generated as ColumnJson (postgres keeps json and jsonb distinct).
+var allTypesTableContentCockroach = strings.ReplaceAll(
+	allTypesTableContent,
+	"postgres.ColumnJsonb", "postgres.ColumnJson")
 
 var sampleRangeTableContent = `
 //

--- a/tests/postgres/generator_test.go
+++ b/tests/postgres/generator_test.go
@@ -1041,10 +1041,10 @@ type allTypesTable struct {
 	UUID                 postgres.ColumnString
 	XMLPtr               postgres.ColumnString
 	XML                  postgres.ColumnString
-	JSONPtr              postgres.ColumnString
-	JSON                 postgres.ColumnString
-	JsonbPtr             postgres.ColumnString
-	Jsonb                postgres.ColumnString
+	JSONPtr              postgres.ColumnJson
+	JSON                 postgres.ColumnJson
+	JsonbPtr             postgres.ColumnJsonb
+	Jsonb                postgres.ColumnJsonb
 	IntegerArrayPtr      postgres.ColumnIntegerArray
 	IntegerArray         postgres.ColumnIntegerArray
 	TextArrayPtr         postgres.ColumnStringArray
@@ -1145,10 +1145,10 @@ func newAllTypesTableImpl(schemaName, tableName, alias string) allTypesTable {
 		UUIDColumn                 = postgres.StringColumn("uuid")
 		XMLPtrColumn               = postgres.StringColumn("xml_ptr")
 		XMLColumn                  = postgres.StringColumn("xml")
-		JSONPtrColumn              = postgres.StringColumn("json_ptr")
-		JSONColumn                 = postgres.StringColumn("json")
-		JsonbPtrColumn             = postgres.StringColumn("jsonb_ptr")
-		JsonbColumn                = postgres.StringColumn("jsonb")
+		JSONPtrColumn              = postgres.JsonColumn("json_ptr")
+		JSONColumn                 = postgres.JsonColumn("json")
+		JsonbPtrColumn             = postgres.JsonbColumn("jsonb_ptr")
+		JsonbColumn                = postgres.JsonbColumn("jsonb")
 		IntegerArrayPtrColumn      = postgres.IntegerArrayColumn("integer_array_ptr")
 		IntegerArrayColumn         = postgres.IntegerArrayColumn("integer_array")
 		TextArrayPtrColumn         = postgres.StringArrayColumn("text_array_ptr")


### PR DESCRIPTION
Add PostgreSQL json and jsonb columns (JsonExpression, JsonbExpression). jsonb is a superset: containment, existence and deletion operators only exist on JsonbExpression, so applying them to a json expression is a compile-time error and converting requires an explicit cast (CAST(...).AS_JSONB() / AS_JSON()). This keeps the builder honest - code that compiles is valid SQL.

- JsonExpression: ->, ->>, #>, #>>, ||, EQ/NOT_EQ
- JsonbExpression: all of the above plus @>, <@, ?, ?|, ?&, -, #-, Remove/RemovePath
- ColumnJson / ColumnJsonb, JsonColumn / JsonbColumn
- JSON(value)/JSONB(value) literals, CAST(...).AS_JSON()/AS_JSONB()
- json/jsonb functions (JSON_BUILD_OBJECT/ARRAY, JSONB_BUILD_OBJECT/ARRAY, TO_JSON(B), JSON_(B)_ARRAY_LENGTH, JSON_(B)_EXTRACT_PATH, JSON_(B)_OBJECT, JSONB_PRETTY) each typed to the matching expression type
- JSON_AGG/JSONB_AGG with embedded ORDER BY (aggregate machinery)
- Generator maps json->JsonColumn, jsonb->JsonbColumn
- Cross-type tests assert the explicit-cast requirement

## SQL dialect decisions

The json/jsonb types and all operator + function wrappers are **PostgreSQL-only**. No other dialect ships a json or jsonb type in this PR (verified: `mysql/` and `sqlite/` are untouched). The generator gates on `SourceDialect`, so non-PostgreSQL databases don't regress:

- **PostgreSQL** — full support: distinct `Json`/`Jsonb` column types, the complete operator set, and all json functions below.
- **CockroachDB** — Postgres-compatible generator, but Cockroach collapses `json` into `jsonb` at the storage level. Both `json` and `jsonb` columns therefore map to a single `Json` column type here (no separate jsonb ops).
- **MySQL** — native `json` type has no jsonb distinction and no json-only operators, so it stays a plain `String` column. No `mysql.JsonExpression` is introduced.
- **SQLite** — no json column type added.

### Functions implemented (all `postgres` package)

- Builders: `JSON_BUILD_OBJECT` / `JSONB_BUILD_OBJECT`, `JSON_BUILD_ARRAY` / `JSONB_BUILD_ARRAY`, `JSON_OBJECT` / `JSONB_OBJECT`
- Coercion: `TO_JSON` / `TO_JSONB` (typed to their matching expression)
- Introspection: `JSON_ARRAY_LENGTH` / `JSONB_ARRAY_LENGTH`, `JSON_EXTRACT_PATH` / `JSONB_EXTRACT_PATH`, `JSONB_PRETTY`
- Aggregates: `JSON_AGG`, `JSONB_AGG` (and `ARRAY_AGG`) with embedded `.ORDER_BY(...)`

`json`-typed functions return `JsonExpression`; `jsonb`-typed return `JsonbExpression`; the two length functions and `JSONB_PRETTY` return scalar (`IntegerExpression` / `StringExpression`). **No json functions are implemented for MySQL or SQLite** in this PR.

## TODO / next steps

- **Reconcile with #618 (aggregate ORDER BY).** Both this PR and #618 add `internal/jet/aggregate_functions.go` + `postgres/aggregate_functions.go`. They are mergeable now but will conflict on the same files when the second merges — decide which lands first and rebase the other.
- **MySQL json type** is a natural follow-up (`mysql.JsonExpression` + json functions) but is intentionally out of scope here.
- **SQLite json1 functions** (`json_extract`, `json_each`, ...) are not covered — SQLite's json support has no jsonb subset, so it would be a distinct design rather than a port of this one.
- **json-to-row functions** (`json_to_record`, `jsonb_to_recordset`, `json_populate_record`) are not wrapped; the `->`/`#>` operators cover the common path today.